### PR TITLE
teltek/PuMuKIT2-stats-ui-bundle#8 StatsBundle: Added 'criteria_series…

### DIFF
--- a/src/Pumukit/StatsBundle/Controller/APIController.php
+++ b/src/Pumukit/StatsBundle/Controller/APIController.php
@@ -152,7 +152,7 @@ class APIController extends Controller implements NewAdminController
         $options['sort'] = $sort;
         $options['group_by'] = $groupBy;
 
-        list($views, $total) = $viewsService->getTotalViewedGroupedByMmobj(new \MongoId($mmobjId), $criteria, $options);
+        list($views, $total) = $viewsService->getTotalViewedGroupedByMmobj(new \MongoId($mmobjId), $options);
 
         $views = array(
             'limit' => $limit,
@@ -193,7 +193,7 @@ class APIController extends Controller implements NewAdminController
         $options['sort'] = $sort;
         $options['group_by'] = $groupBy;
 
-        list($views, $total) = $viewsService->getTotalViewedGroupedBySeries(new \MongoId($seriesId), $criteria, $options);
+        list($views, $total) = $viewsService->getTotalViewedGroupedBySeries(new \MongoId($seriesId), $options);
 
         $views = array(
             'limit' => $limit,

--- a/src/Pumukit/StatsBundle/Controller/APIController.php
+++ b/src/Pumukit/StatsBundle/Controller/APIController.php
@@ -96,6 +96,7 @@ class APIController extends Controller implements NewAdminController
 
         $groupBy = $request->get('group_by') ?: 'month';
 
+        //NOTE: $criteria is the same as $criteria_mmobj to provide backwards compatibility.
         $criteria_mmobj = $request->get('criteria_mmobj') ?: $criteria;
         $criteria_series = $request->get('criteria_series') ?: array();
 

--- a/src/Pumukit/StatsBundle/Controller/APIController.php
+++ b/src/Pumukit/StatsBundle/Controller/APIController.php
@@ -96,20 +96,28 @@ class APIController extends Controller implements NewAdminController
 
         $groupBy = $request->get('group_by') ?: 'month';
 
+        $criteria_mmobj = $request->get('criteria_mmobj') ?: $criteria;
+        $criteria_series = $request->get('criteria_series') ?: array();
+
         $options['from_date'] = $fromDate;
         $options['to_date'] = $toDate;
         $options['limit'] = $limit;
         $options['page'] = $page;
         $options['sort'] = $sort;
         $options['group_by'] = $groupBy;
+        $options['criteria_mmobj'] = $criteria_mmobj;
+        $options['criteria_series'] = $criteria_series;
 
-        list($views, $total) = $viewsService->getTotalViewedGrouped($criteria, $options);
+        list($views, $total) = $viewsService->getTotalViewedGrouped($options);
 
         $views = array(
             'limit' => $limit,
             'page' => $page,
             'total' => $total,
-            'criteria' => $criteria,
+            'criteria' => array(
+                'criteria_mmobj' => $criteria_mmobj,
+                'criteria_series' => $criteria_series,
+            ),
             'sort' => $sort,
             'group_by' => $groupBy,
             'from_date' => $fromDate,
@@ -150,7 +158,6 @@ class APIController extends Controller implements NewAdminController
             'limit' => $limit,
             'page' => $page,
             'total' => $total,
-            'criteria' => $criteria,
             'sort' => $sort,
             'group_by' => $groupBy,
             'from_date' => $fromDate,
@@ -192,7 +199,6 @@ class APIController extends Controller implements NewAdminController
             'limit' => $limit,
             'page' => $page,
             'total' => $total,
-            'criteria' => $criteria,
             'sort' => $sort,
             'group_by' => $groupBy,
             'from_date' => $fromDate,

--- a/src/Pumukit/StatsBundle/Tests/Services/StatsServiceTest.php
+++ b/src/Pumukit/StatsBundle/Tests/Services/StatsServiceTest.php
@@ -229,14 +229,14 @@ class StatsServiceTest extends WebTestCase
         $this->assertEquals($total, 5);
         list($mostViewed, $total) =  $service->getMmobjsMostViewedByRange(array('not_a_parameter' => 'not_a_value'));
         $this->assertEquals($total, 0);
-        list($mostViewed, $total) =  $service->getMmobjsMostViewedByRange(array('title.en' => 'New'), array('limit' => 2,'from_date' => new \DateTime('-10 days')));
+        list($mostViewed, $total) =  $service->getMmobjsMostViewedByRange(array('title.en' => 'New'), array('limit' => 2,'from_date' => new \DateTime('-11 days')));
         $this->assertEquals(array($listMapped[1], $listMapped[2]), $mostViewed);
         $this->assertEquals($total, 3);
-        list($mostViewed, $total) =  $service->getMmobjsMostViewedByRange(array('title.en' => 'New'), array('limit' => 2,'from_date' => new \DateTime('-10 days'), 'page' => 1));
+        list($mostViewed, $total) =  $service->getMmobjsMostViewedByRange(array('title.en' => 'New'), array('limit' => 2,'from_date' => new \DateTime('-11 days'), 'page' => 1));
         $this->assertEquals(array($listMapped[3]), $mostViewed);
         $this->assertEquals($total, 3);
 
-        list($mostViewed, $total) =  $service->getMmobjsMostViewedByRange(array(), array('from_date' => new \DateTime('-20 days'), 'to_date' => new \DateTime('-10 days')));
+        list($mostViewed, $total) =  $service->getMmobjsMostViewedByRange(array(), array('from_date' => new \DateTime('-21 days'), 'to_date' => new \DateTime('-9 days')));
         $this->assertEquals(array($listMapped[0], $listMapped[1]), $mostViewed);
         $this->assertEquals($total, 2);
     }


### PR DESCRIPTION
…' to views.json api

This change will help when filtering by either series or mmobj criteria.

* Edited 'getTotalViewedGrouped()' to accept filtering (criteria) on both series and mmobjs.
 * Added two new parameters to api, 'criteria_series' and 'criteria_mmobj'.
 * If used, the parameter 'criteria' will be equivalent to 'criteria_mmobj'.
 * Changed service functions to get the criteria parameters through 'options'.
* Removed unused 'criteria' on api/media/views/mmobj.json and api/media/views/series.json