### PR TITLE
#123 WebTVBundle: Removed deprecated 'dates'

### DIFF
--- a/src/Pumukit/WebTVBundle/Controller/SearchController.php
+++ b/src/Pumukit/WebTVBundle/Controller/SearchController.php
@@ -121,12 +121,6 @@ class SearchController extends Controller implements WebTVController
         ->getRepository('PumukitSchemaBundle:MultimediaObject')
         ->createStandardQueryBuilder()->sort('record_date','asc')->limit(1)
         ->getQuery()->getSingleResult();
-        //TODO: $minRecordDate Unused. Remove for 2.3 version
-        $minRecordDate = $firstMmobj ?
-          $firstMmobj->getRecordDate()->format('m/d/Y') :
-          date('m/d/Y', time() - (365 * 24 * 60 * 60));
-        //TODO: $maxRecordDate Unused. Remove for 2.3 version
-        $maxRecordDate = date('m/d/Y');
         // --- Get years array ---
         $searchYears = $this->getMmobjsYears();
 
@@ -143,8 +137,6 @@ class SearchController extends Controller implements WebTVController
         'number_cols' => $numberCols,
         'languages' => $searchLanguages,
         'blocked_tag' => $blockedTag,
-        'min_record_date' => $minRecordDate, //TODO: Unused. Remove for 2.3 version
-        'max_record_date' => $maxRecordDate, //TODO: Unused. Remove for 2.3 version
         'search_years' => $searchYears,
         'total_objects' => $totalObjects);
     }

--- a/src/Pumukit/WebTVBundle/Controller/SearchController.php
+++ b/src/Pumukit/WebTVBundle/Controller/SearchController.php
@@ -116,11 +116,6 @@ class SearchController extends Controller implements WebTVController
         ->createStandardQueryBuilder()
         ->distinct('tracks.language')
         ->getQuery()->execute();
-        // --- Query to get oldest date ---
-        $firstMmobj = $this->get('doctrine_mongodb')
-        ->getRepository('PumukitSchemaBundle:MultimediaObject')
-        ->createStandardQueryBuilder()->sort('record_date','asc')->limit(1)
-        ->getQuery()->getSingleResult();
         // --- Get years array ---
         $searchYears = $this->getMmobjsYears();
 


### PR DESCRIPTION
Fixes #123
Note: I checked the Géant bundle just in case. These values are not being used in the overrided layout, so everything is alright:
Géant file: [Search/filtersmultimediaobjects.html.twig](
https://github.com/teltek/PuMuKIT2-geant-bundle/blob/master/Resources/views/Search/filtersmultimediaobjects.html.twig)