### PR TITLE
Show groups to add according to user scope

### DIFF
--- a/src/Pumukit/NewAdminBundle/Controller/AdminController.php
+++ b/src/Pumukit/NewAdminBundle/Controller/AdminController.php
@@ -336,4 +336,24 @@ class AdminController extends ResourceController implements NewAdminController
 
         return $form;
     }
+
+    /**
+     * Get all groups for logged in user
+     * according to user scope.
+     *
+     * @return ArrayCollection
+     */
+    public function getAllGroups()
+    {
+        $groupService = $this->get('pumukitschema.group');
+        $userService = $this->get('pumukitschema.user');
+        $loggedInUser = $this->getUser();
+        if ($loggedInUser->isSuperAdmin() || $userService->hasGlobalScope($loggedInUser)) {
+            $allGroups = $groupService->findAll();
+        } else {
+            $allGroups = $loggedInUser->getGroups();
+        }
+
+        return $allGroups;
+    }
 }

--- a/src/Pumukit/NewAdminBundle/Controller/MultimediaObjectController.php
+++ b/src/Pumukit/NewAdminBundle/Controller/MultimediaObjectController.php
@@ -202,8 +202,7 @@ class MultimediaObjectController extends SortableAdminController implements NewA
         $allBundles = $this->container->getParameter('kernel.bundles');
         $opencastExists = array_key_exists('PumukitOpencastBundle', $allBundles);
 
-        $groupService = $this->get('pumukitschema.group');
-        $allGroups = $groupService->findAll();
+        $allGroups = $this->getAllGroups();
 
         return array(
                      'mm' => $resource,
@@ -252,10 +251,9 @@ class MultimediaObjectController extends SortableAdminController implements NewA
 
         $factoryService = $this->get('pumukitschema.factory');
         $personService = $this->get('pumukitschema.person');
-        $groupService = $this->get('pumukitschema.group');
 
         $personalScopeRoleCode = $personService->getPersonalScopeRoleCode();
-        $allGroups = $groupService->findAll();
+        $allGroups = $this->getAllGroups();
 
         try {
             $personalScopeRole = $personService->getPersonalScopeRole();
@@ -413,8 +411,8 @@ class MultimediaObjectController extends SortableAdminController implements NewA
         if (null === $roles) {
             throw new \Exception('Not found any role.');
         }
-        $groupService = $this->get('pumukitschema.group');
-        $allGroups = $groupService->findAll();
+
+        $allGroups = $this->getAllGroups();
 
         return $this->render('PumukitNewAdminBundle:MultimediaObject:edit.html.twig',
                              array(
@@ -1071,8 +1069,7 @@ class MultimediaObjectController extends SortableAdminController implements NewA
         $dm = $this->get('doctrine_mongodb.odm.document_manager');
         $embeddedBroadcastService = $this->get('pumukitschema.embeddedbroadcast');
         $broadcasts = $embeddedBroadcastService->getAllTypes();
-        $groupService = $this->get('pumukitschema.group');
-        $allGroups = $groupService->findAll();
+        $allGroups = $this->getAllGroups();
         $template = $multimediaObject->isPrototype() ? '_template' : '';
         if (($request->isMethod('PUT') || $request->isMethod('POST'))) {
             try {
@@ -1251,7 +1248,11 @@ class MultimediaObjectController extends SortableAdminController implements NewA
                                                 );
             $addGroupsIds[] = new \MongoId($group->getId());
         }
-        $groupsToDelete = $groupService->findByIdNotIn($addGroupsIds);
+        $allGroups = $this->getAllGroups();
+        foreach ($allGroups as $group) {
+            $allGroupsIds[] = new \MongoId($group->getId());
+        }
+        $groupsToDelete = $groupService->findByIdNotInOf($addGroupsIds, $allGroupsIds);
         foreach ($groupsToDelete as $group) {
             $deleteGroups[$group->getId()] = array(
                                                    'key' => $group->getKey(),

--- a/src/Pumukit/NewAdminBundle/Controller/SeriesController.php
+++ b/src/Pumukit/NewAdminBundle/Controller/SeriesController.php
@@ -120,8 +120,7 @@ class SeriesController extends AdminController implements NewAdminController
 
         $personalScopeRoleCode = $personService->getPersonalScopeRoleCode();
 
-        $groupService = $this->get('pumukitschema.group');
-        $allGroups = $groupService->findAll();
+        $allGroups = $this->getAllGroups();
 
         try {
             $personalScopeRole = $personService->getPersonalScopeRole();
@@ -594,8 +593,7 @@ class SeriesController extends AdminController implements NewAdminController
         $dm = $this->get('doctrine_mongodb.odm.document_manager');
         $mmRepo = $dm->getRepository('PumukitSchemaBundle:MultimediaObject');
         $broadcasts = $this->get('pumukitschema.embeddedbroadcast')->getAllTypes();
-        $groupService = $this->get('pumukitschema.group');
-        $allGroups = $groupService->findAll();
+        $allGroups = $this->getAllGroups();
         $seriesService = $this->get('pumukitschema.series');
         $embeddedBroadcast = false;
         $sameBroadcast = $seriesService->sameEmbeddedBroadcast($series);

--- a/src/Pumukit/SchemaBundle/Repository/GroupRepository.php
+++ b/src/Pumukit/SchemaBundle/Repository/GroupRepository.php
@@ -27,4 +27,24 @@ class GroupRepository extends DocumentRepository
             ->getQuery()
             ->execute();
     }
+
+    /**
+     * Find groups not in
+     * the given array but
+     * in the total of groups
+     * given.
+     *
+     * @param array $ids
+     * @param array $total
+     *
+     * @return Cursor
+     */
+    public function findByIdNotInOf($ids = array(), $total = array())
+    {
+        return $this->createQueryBuilder()
+            ->field('_id')->in($total)
+            ->field('_id')->notIn($ids)
+            ->getQuery()
+            ->execute();
+    }
 }

--- a/src/Pumukit/SchemaBundle/Services/GroupService.php
+++ b/src/Pumukit/SchemaBundle/Services/GroupService.php
@@ -339,4 +339,20 @@ class GroupService
     {
         return $this->repo->findByIdNotIn($ids);
     }
+
+    /**
+     * Find groups not in
+     * the given array but
+     * in the total of groups
+     * given.
+     *
+     * @param array $ids
+     * @param array $total
+     *
+     * @return Cursor
+     */
+    public function findByIdNotInOf($ids = array(), $total = array())
+    {
+        return $this->repo->findByIdNotInOf($ids, $total);
+    }
 }

--- a/src/Pumukit/SchemaBundle/Tests/Repository/GroupRepositoryTest.php
+++ b/src/Pumukit/SchemaBundle/Tests/Repository/GroupRepositoryTest.php
@@ -76,4 +76,61 @@ class GroupRepositoryTest extends WebTestCase
         $this->assertTrue(in_array($group2, $groups));
         $this->assertFalse(in_array($group3, $groups));
     }
+
+    public function testFindByIdNotInOf()
+    {
+        $group1 = new Group();
+        $group1->setKey('Group1');
+        $group1->setName('Group 1');
+
+        $group2 = new Group();
+        $group2->setKey('Group2');
+        $group2->setName('Group 2');
+
+        $group3 = new Group();
+        $group3->setKey('Group3');
+        $group3->setName('Group 3');
+
+        $group4 = new Group();
+        $group4->setKey('Group4');
+        $group4->setName('Group 4');
+
+        $this->dm->persist($group1);
+        $this->dm->persist($group2);
+        $this->dm->persist($group3);
+        $this->dm->persist($group4);
+        $this->dm->flush();
+
+        $ids = array(new \MongoId($group1->getId()), new \MongoId($group3->getId()));
+        $total = array(new \MongoId($group1->getId()), new \MongoId($group3->getId()), new \MongoId($group4->getId()));
+        $groups = $this->repo->findByIdNotInOf($ids, $total)->toArray();
+        $this->assertFalse(in_array($group1, $groups));
+        $this->assertFalse(in_array($group2, $groups));
+        $this->assertFalse(in_array($group3, $groups));
+        $this->assertTrue(in_array($group4, $groups));
+
+        $ids = array();
+        $total = array(new \MongoId($group1->getId()), new \MongoId($group3->getId()), new \MongoId($group4->getId()));
+        $groups = $this->repo->findByIdNotInOf($ids, $total)->toArray();
+        $this->assertTrue(in_array($group1, $groups));
+        $this->assertFalse(in_array($group2, $groups));
+        $this->assertTrue(in_array($group3, $groups));
+        $this->assertTrue(in_array($group4, $groups));
+
+        $ids = array(new \MongoId($group1->getId()), new \MongoId($group3->getId()));
+        $total = array();
+        $groups = $this->repo->findByIdNotInOf($ids, $total)->toArray();
+        $this->assertFalse(in_array($group1, $groups));
+        $this->assertFalse(in_array($group2, $groups));
+        $this->assertFalse(in_array($group3, $groups));
+        $this->assertFalse(in_array($group4, $groups));
+
+        $ids = array();
+        $total = array();
+        $groups = $this->repo->findByIdNotInOf($ids, $total)->toArray();
+        $this->assertFalse(in_array($group1, $groups));
+        $this->assertFalse(in_array($group2, $groups));
+        $this->assertFalse(in_array($group3, $groups));
+        $this->assertFalse(in_array($group4, $groups));
+    }
 }

--- a/src/Pumukit/SchemaBundle/Tests/Services/GroupServiceTest.php
+++ b/src/Pumukit/SchemaBundle/Tests/Services/GroupServiceTest.php
@@ -470,6 +470,63 @@ class GroupServiceTest extends WebTestCase
         $this->assertFalse(in_array($group3, $groups));
     }
 
+    public function testFindByIdNotInOf()
+    {
+        $group1 = new Group();
+        $group1->setKey('Group1');
+        $group1->setName('Group 1');
+
+        $group2 = new Group();
+        $group2->setKey('Group2');
+        $group2->setName('Group 2');
+
+        $group3 = new Group();
+        $group3->setKey('Group3');
+        $group3->setName('Group 3');
+
+        $group4 = new Group();
+        $group4->setKey('Group4');
+        $group4->setName('Group 4');
+
+        $this->dm->persist($group1);
+        $this->dm->persist($group2);
+        $this->dm->persist($group3);
+        $this->dm->persist($group4);
+        $this->dm->flush();
+
+        $ids = array(new \MongoId($group1->getId()), new \MongoId($group3->getId()));
+        $total = array(new \MongoId($group1->getId()), new \MongoId($group3->getId()), new \MongoId($group4->getId()));
+        $groups = $this->groupService->findByIdNotInOf($ids, $total)->toArray();
+        $this->assertFalse(in_array($group1, $groups));
+        $this->assertFalse(in_array($group2, $groups));
+        $this->assertFalse(in_array($group3, $groups));
+        $this->assertTrue(in_array($group4, $groups));
+
+        $ids = array();
+        $total = array(new \MongoId($group1->getId()), new \MongoId($group3->getId()), new \MongoId($group4->getId()));
+        $groups = $this->groupService->findByIdNotInOf($ids, $total)->toArray();
+        $this->assertTrue(in_array($group1, $groups));
+        $this->assertFalse(in_array($group2, $groups));
+        $this->assertTrue(in_array($group3, $groups));
+        $this->assertTrue(in_array($group4, $groups));
+
+        $ids = array(new \MongoId($group1->getId()), new \MongoId($group3->getId()));
+        $total = array();
+        $groups = $this->groupService->findByIdNotInOf($ids, $total)->toArray();
+        $this->assertFalse(in_array($group1, $groups));
+        $this->assertFalse(in_array($group2, $groups));
+        $this->assertFalse(in_array($group3, $groups));
+        $this->assertFalse(in_array($group4, $groups));
+
+        $ids = array();
+        $total = array();
+        $groups = $this->groupService->findByIdNotInOf($ids, $total)->toArray();
+        $this->assertFalse(in_array($group1, $groups));
+        $this->assertFalse(in_array($group2, $groups));
+        $this->assertFalse(in_array($group3, $groups));
+        $this->assertFalse(in_array($group4, $groups));
+    }
+
     public function testCountAdminMultimediaObjectsInGroup()
     {
         $group1 = new Group();

--- a/src/Pumukit/TemplateBundle/Controller/CrudController.php
+++ b/src/Pumukit/TemplateBundle/Controller/CrudController.php
@@ -55,8 +55,8 @@ class CrudController extends Controller
         return array(
             'templates' => $templates,
             'active' => $active,
-            'delete_form' => $deleteForm->createView(),
-            'edit_form' => $editForm->createView(),
+            'delete_form' => $deleteForm ? $deleteForm->createView() : null,
+            'edit_form' => $editForm ? $editForm->createView() : null,
         );
     }
 

--- a/src/Pumukit/TemplateBundle/Resources/config/services.xml
+++ b/src/Pumukit/TemplateBundle/Resources/config/services.xml
@@ -12,7 +12,7 @@
       <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" />
     </service>
 
-    <service id="pumukit_template.menu" class="Pumukit\TemplateBundle\Services\MenuServices">
+    <service id="pumukit_template.menu" class="Pumukit\TemplateBundle\Services\MenuService">
       <tag name="pumukitnewadmin.menuitem" />
     </service>
   </services>


### PR DESCRIPTION
Show groups to add to a broadcast or to admin a multimedia object:
- If user has global scope, all existing groups are shown
- Otherwise, only the groups of the logged in user are shown