### PR TITLE
Wizard: show only series of admin in series step

### DIFF
--- a/src/Pumukit/SchemaBundle/Repository/SeriesRepository.php
+++ b/src/Pumukit/SchemaBundle/Repository/SeriesRepository.php
@@ -397,7 +397,7 @@ class SeriesRepository extends DocumentRepository
      */
     public function findWithTagAndSeriesType($tag, $seriesType, $sort = array(), $limit = 0, $page = 0)
     {
-        $qb = $this->createBuilderWithTagAndSeriesType($tag, $seriesType,  $sort);
+        $qb = $this->createBuilderWithTagAndSeriesType($tag, $seriesType, $sort);
 
         if ($limit > 0) {
             $qb->limit($limit)->skip($limit * $page);
@@ -415,7 +415,7 @@ class SeriesRepository extends DocumentRepository
      *
      * @return QueryBuilder
      */
-    public function createBuilderWithTagAndSeriesType($tag, $seriesType,  $sort = array())
+    public function createBuilderWithTagAndSeriesType($tag, $seriesType, $sort = array())
     {
         $referencedSeries = $this->getDocumentManager()
             ->getRepository('PumukitSchemaBundle:MultimediaObject')

--- a/src/Pumukit/SchemaBundle/Services/SeriesService.php
+++ b/src/Pumukit/SchemaBundle/Services/SeriesService.php
@@ -91,16 +91,17 @@ class SeriesService
      * with owner role code or share groups
      * with the multimedia object.
      *
-     * @param User   $user
-     * @param string $roleOwnerCode
-     * @param array  $sort
-     * @param int    $limit
+     * @param User    $user
+     * @param boolean $onlyAdminSeries
+     * @param string  $roleOwnerCode
+     * @param array   $sort
+     * @param int     $limit
      *
      * @return ArrayCollection
      */
-    public function getSeriesOfUser(User $user, $roleOwnerCode = '', $sort = array(), $limit = 0)
+    public function getSeriesOfUser(User $user, $onlyAdminSeries = false, $roleOwnerCode = '', $sort = array(), $limit = 0)
     {
-        if (($permissionProfile = $user->getPermissionProfile()) && $permissionProfile->isGlobal()) {
+        if (($permissionProfile = $user->getPermissionProfile()) && $permissionProfile->isGlobal() && !$onlyAdminSeries) {
             return $this->repo->findBy(array(), $sort, $limit);
         }
         $groups = array();

--- a/src/Pumukit/WizardBundle/Controller/DefaultController.php
+++ b/src/Pumukit/WizardBundle/Controller/DefaultController.php
@@ -79,8 +79,9 @@ class DefaultController extends Controller
             /* $limit = 30; */
             $seriesService = $this->get('pumukitschema.series');
             $user = $this->getUser();
+            $reuseAdminSeries = $this->getParameter('pumukit_wizard.reuse_admin_series');
             $personalScopeRoleCode = $this->getParameter('pumukitschema.personal_scope_role_code');
-            $userSeries = $seriesService->getSeriesOfUser($user, $personalScopeRoleCode, $sort, $limit);
+            $userSeries = $seriesService->getSeriesOfUser($user, $reuseAdminSeries, $personalScopeRoleCode, $sort, $limit);
         }
         $showTags = $this->container->getParameter('pumukit_wizard.show_tags', false);
         $showObjectLicense = $this->container->getParameter('pumukit_wizard.show_object_license', false);

--- a/src/Pumukit/WizardBundle/DependencyInjection/Configuration.php
+++ b/src/Pumukit/WizardBundle/DependencyInjection/Configuration.php
@@ -49,6 +49,10 @@ class Configuration implements ConfigurationInterface
           ->defaultFalse()
           ->info('Enable adding new multimedia object to an existing series belonging to the logged in user.')
         ->end()
+        ->booleanNode('reuse_admin_series')
+          ->defaultFalse()
+          ->info('When reuse_series is set to True, the admin user can reuse any series or just the series he/she created.')
+        ->end()
       ->end();
 
         return $treeBuilder;

--- a/src/Pumukit/WizardBundle/DependencyInjection/PumukitWizardExtension.php
+++ b/src/Pumukit/WizardBundle/DependencyInjection/PumukitWizardExtension.php
@@ -29,6 +29,7 @@ class PumukitWizardExtension extends Extension
         $container->setParameter('pumukit_wizard.show_object_license', $config['show_object_license']);
         $container->setParameter('pumukit_wizard.mandatory_title', $config['mandatory_title']);
         $container->setParameter('pumukit_wizard.reuse_series', $config['reuse_series']);
+        $container->setParameter('pumukit_wizard.reuse_admin_series', $config['reuse_admin_series']);
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');


### PR DESCRIPTION
Added parameter to chose this option:
```
pumukit_wizard:
    reuse_series: true
    reuse_admin_series: true
```
By default `reuse_admin_series` is set to false.