### PR TITLE
InspectionBundle: Defensive programming for 'duration'.

### DIFF
--- a/src/Pumukit/InspectionBundle/Services/InspectionFfprobeService.php
+++ b/src/Pumukit/InspectionBundle/Services/InspectionFfprobeService.php
@@ -36,7 +36,10 @@ class InspectionFfprobeService implements InspectionServiceInterface
                 "nor audio tracks\n" . $file);
         }
 
-        $duration = ceil(intval((string)$json->format->duration));
+        $duration = 0;
+        if(isset($json->format->duration)) {
+            $duration = ceil(intval((string) $json->format->duration));
+        }
 
         return $duration;
     }
@@ -78,12 +81,12 @@ class InspectionFfprobeService implements InspectionServiceInterface
                     break;
 
                 case "audio":
-                    $track->setAcodec((string)$stream->codec_name); 
+                    $track->setAcodec((string)$stream->codec_name);
                     $track->setChannels(intval($stream->channels));
                     break;
-                
+
             }
-            $track->setOnlyAudio($only_audio);                
+            $track->setOnlyAudio($only_audio);
         }
     }
 
@@ -107,7 +110,7 @@ class InspectionFfprobeService implements InspectionServiceInterface
         $process->setTimeout(60);
         $process->run();
         if (!$process->isSuccessful()) {
-            $message = 'Exception executing "' . $command . '": ' . $process->getExitCode() . ' ' . 
+            $message = 'Exception executing "' . $command . '": ' . $process->getExitCode() . ' ' .
               $process->getExitCodeText().'. '.$process->getErrorOutput();
             $this->logger->error($message);
             throw new \RuntimeException($message);


### PR DESCRIPTION
In videos with no duration, ffprobe may not return any 'duration' property at all in the json. This check prevents that from causing an error 500