### PR TITLE
TTK-13188 Add error template

### DIFF
--- a/app/Resources/TwigBundle/views/Exception/error.html.twig
+++ b/app/Resources/TwigBundle/views/Exception/error.html.twig
@@ -1,0 +1,8 @@
+{% extends ['PumukitWebTVBundle::layout.html.twig', '::base.html.twig'] %}
+{% block body %}
+  <h1>{% trans %}Oops! An Error Occurred{% endtrans %}</h1>
+  <h2>{% trans %}The server returned a{% endtrans %} "{{ status_code }} {{ status_text }}".</h2>
+  <div>
+    <p>{% trans %}Something is broken. Please let us know what you were doing when this error occurred. We will fix it as soon as possible. Sorry for any inconvenience caused.{% endtrans %}</p>
+  </div>
+{% endblock %}


### PR DESCRIPTION
I have found 3 possible ways to reach the error page:
- Full request of a page
- Partial request of a page (with the function render(controller(...)) in a twig template)
- Ajax request of a partial page

In all of these requests, if there is a 500 error, in all of them, the full error page is loaded.
I couldn't achieve to render one layout or another according to type request (if the call is from ajax or not). This code I haven't commited because it doesn't work, but it is the main idea:
```
{% extends app.request.xmlHttpRequest
? '::ajax-layout.html.twig'
     : ['PumukitWebTVBundle::layout.html.twig', '::base.html.twig'] %}
```

If you see a better way to improve and extend from different layout according to request, go ahead.
I haven't found a way to find out if the call is being made from render(controller...)) function. The only possible way is with a parameter in the request.

Code review and pull request.