### PR TITLE
Bugfix 13176 http iframe

### DIFF
--- a/src/Pumukit/WebTVBundle/Resources/views/Index/403forbidden.html.twig
+++ b/src/Pumukit/WebTVBundle/Resources/views/Index/403forbidden.html.twig
@@ -13,7 +13,7 @@
         <br/>
         {% if not is_granted('IS_AUTHENTICATED_FULLY') %}
         <div class="text-center">
-          <button id="pumukit_forbidden_login" type="submit" class="btn btn-primary btn-flat" name="submit" title="Log In">Log In</button>
+          <button id="pumukit_forbidden_login" type="submit" class="btn btn-primary btn-flat" name="submit" title="{% trans %}Log In{% endtrans %}">{% trans %}Log In{% endtrans %}</button>
         </div>
         {% endif %}
       {% endif %}

--- a/src/Pumukit/WebTVBundle/Resources/views/MultimediaObject/player.html.twig
+++ b/src/Pumukit/WebTVBundle/Resources/views/MultimediaObject/player.html.twig
@@ -9,11 +9,11 @@ $(window).resize(function(){
 });
 </script>
 {% if magic_url is defined and magic_url %}
-  {% set url_iframe = url('pumukit_videoplayer_magicindex', {'secret':multimediaObject.secret, 'autostart': autostart})%}
+  {% set url_iframe = path('pumukit_videoplayer_magicindex', {'secret':multimediaObject.secret, 'autostart': autostart})%}
 {% elseif track is defined %}
-  {% set url_iframe = url('pumukit_videoplayer_index', {'id':multimediaObject.id, 'track_id':track.id, 'autostart': autostart}) %}
+  {% set url_iframe = path('pumukit_videoplayer_index', {'id':multimediaObject.id, 'track_id':track.id, 'autostart': autostart}) %}
 {% else %}
-  {% set url_iframe = url('pumukit_videoplayer_index', {'id':multimediaObject.id, 'autostart': autostart}) %}
+  {% set url_iframe = path('pumukit_videoplayer_index', {'id':multimediaObject.id, 'autostart': autostart}) %}
 {% endif %}
 <iframe src="{{ url_iframe|raw }}"
         id="paellaiframe"


### PR DESCRIPTION
* In Twig template of WebTVBundle MultimediaObjet player.html.twig it was being use the url() function instead of path()
* In Twig template of 403forbidden.html.twig the trans tag of `Log In` text was missing.