### PR TITLE
Feature 13182 duration 0 encoder

### DIFF
--- a/src/Pumukit/EncoderBundle/DependencyInjection/Configuration.php
+++ b/src/Pumukit/EncoderBundle/DependencyInjection/Configuration.php
@@ -45,6 +45,8 @@ class Configuration implements ConfigurationInterface
                     ->useAttributeAsKey('name')
                     ->prototype('array')
                         ->children()
+                            ->booleanNode('nocheckduration')->defaultValue(false)
+                                ->info('When true, the usual duration checks are not performed on this profile.')->end()
                             ->booleanNode('display')->defaultValue(false)
                                 ->info('Displays the track')->end()
                             ->booleanNode('wizard')->defaultValue(true)

--- a/src/Pumukit/EncoderBundle/Services/JobService.php
+++ b/src/Pumukit/EncoderBundle/Services/JobService.php
@@ -482,7 +482,9 @@ class JobService
     public function searchError($profile, $var, $duration_in, $duration_end)
     {
         // This allows to configure a profile for videos without timestamps to be reindexed.
-        if(isset($profile['nocheckduration']) && $profile['nocheckduration']) return true;
+        if (isset($profile['nocheckduration']) && $profile['nocheckduration']) {
+            return true;
+        }
 
         $duration_conf = 25;
         if (($duration_in < $duration_end - $duration_conf) || ($duration_in > $duration_end + $duration_conf)) {


### PR DESCRIPTION
Adds an optional property to the encoders that, if set to true, skips the 'noduration' checks.

Useful if the profile is meant to reindex the files.