### PR TITLE
TTK-13182 Fixed wrong parameter passing.

### DIFF
--- a/src/Pumukit/EncoderBundle/Services/JobService.php
+++ b/src/Pumukit/EncoderBundle/Services/JobService.php
@@ -440,7 +440,7 @@ class JobService
             $this->logger->addInfo('[execute] duration: '.$duration);
 
             //Check for different durations. Throws exception if they don't match.
-            $this->searchError($profile['app'], $out, $job->getDuration(), $duration);
+            $this->searchError($profile, $out, $job->getDuration(), $duration);
 
             $job->setTimeend(new \DateTime('now'));
             $job->setStatus(Job::STATUS_FINISHED);


### PR DESCRIPTION
There seems to be a typo.
In searchError, we check `$profile['nocheckduration']`, which would never exist if we don't pass the full `$profile`.

