### PR TITLE
TTK-13340 WizardBundle: add IE workaround for enctype

### DIFF
--- a/src/Pumukit/WizardBundle/Resources/views/pumukit2_wizard.js.twig
+++ b/src/Pumukit/WizardBundle/Resources/views/pumukit2_wizard.js.twig
@@ -46,7 +46,11 @@ $(function(){
             }else{
                 trackForm.action = "{{ path('pumukitwizard_default_multimediaobject')|raw }}";
             }
-            trackForm.enctype = "";
+            try {
+                trackForm.enctype = "";
+            } catch (e) {
+                /* DO NOTHING: IE9 Workaround */
+            }
             trackForm.target = "";
             trackForm.submit();
         }


### PR DESCRIPTION
Follows this other pull request: #309 
After the unification of branches 2.3.x and 2.4.x in the issue #305 , the previous pull request is moved to 2.3.x branch.

The travis may fail because of commented console.log:
```
src/Pumukit/NewAdminBundle/Resources/views/MultimediaObject/acordeon.html.twig:105:

//console.log($(form).serialize());
```