### PR TITLE
Unset track to allow playing dual-stream after paella player commit:

### DIFF
--- a/src/Pumukit/WebTVBundle/Controller/MultimediaObjectController.php
+++ b/src/Pumukit/WebTVBundle/Controller/MultimediaObjectController.php
@@ -44,6 +44,11 @@ class MultimediaObjectController extends PlayerController implements WebTVContro
             return $this->redirect($track->getUrl());
         }
 
+        // If we didn't ask for a specific track, we let the player decide.
+        if(!$request->query->has('track_id')) {
+            $track = null;
+        }
+
         $this->updateBreadcrumbs($multimediaObject);
 
         $editorChapters = $this->getChapterMarks($multimediaObject);

--- a/src/Pumukit/WebTVBundle/Resources/views/MultimediaObject/player.html.twig
+++ b/src/Pumukit/WebTVBundle/Resources/views/MultimediaObject/player.html.twig
@@ -10,8 +10,8 @@ $(window).resize(function(){
 </script>
 {% if magic_url is defined and magic_url %}
   {% set url_iframe = url('pumukit_videoplayer_magicindex', {'secret':multimediaObject.secret, 'autostart': autostart})%}
-{% elseif track is defined %}
-  {% set url_iframe = url('pumukit_videoplayer_index', {'id':multimediaObject.id, 'track_id':track.id, 'autostart': autostart}) %}
+{% elseif track is defined and track %}
+  {% set url_iframe = path('pumukit_videoplayer_index', {'id':multimediaObject.id, 'track_id':track.id, 'autostart': autostart}) %}
 {% else %}
   {% set url_iframe = url('pumukit_videoplayer_index', {'id':multimediaObject.id, 'autostart': autostart}) %}
 {% endif %}


### PR DESCRIPTION
teltek/PuMuKIT2-paella-player-bundle@f28cde54

This change made possible to select one single track from an Opencast video. However, since the WebTVBundle would always set a track, this had the undesirable effect of ALWAYS showing only one track.
Fixed it for 2.2.x