### PR TITLE
Unset track to allow playing dual-stream after changes in commit:

### DIFF
--- a/src/Pumukit/WebTVBundle/Controller/MultimediaObjectController.php
+++ b/src/Pumukit/WebTVBundle/Controller/MultimediaObjectController.php
@@ -82,12 +82,18 @@ class MultimediaObjectController extends PlayerController implements WebTVContro
 
         $request->attributes->set('noindex', true);
 
-        $track = $request->query->has('track_id') ?
-               $multimediaObject->getTrackById($request->query->get('track_id')) :
-               $multimediaObject->getDisplayTrack();
+        $track = null;
 
-        if ($track && $track->containsTag('download')) {
-            return $this->redirect($track->getUrl());
+        if($request->query->has('track_id')) {
+            $track = $multimediaObject->getTrackById($request->query->get('track_id'));
+
+            if (!$track) {
+                throw $this->createNotFoundException();
+            }
+
+            if ($track->containsTag('download')) {
+                return $this->redirect($track->getUrl());
+            }
         }
 
         $this->updateBreadcrumbs($multimediaObject);

--- a/src/Pumukit/WebTVBundle/Controller/MultimediaObjectController.php
+++ b/src/Pumukit/WebTVBundle/Controller/MultimediaObjectController.php
@@ -23,27 +23,31 @@ class MultimediaObjectController extends PlayerController implements WebTVContro
             return $response;
         }
 
-        $track = $request->query->has('track_id') ?
-               $multimediaObject->getTrackById($request->query->get('track_id')) :
-               $multimediaObject->getDisplayTrack();
+        $track = null;
 
-        if (!$track) {
-            throw $this->createNotFoundException();
-        }
+        if($request->query->has('track_id')) {
+            $track = $multimediaObject->getTrackById($request->query->get('track_id'));
 
-        if ($track->containsTag('download')) {
-            return $this->redirect($track->getUrl());
+            if (!$track) {
+                throw $this->createNotFoundException();
+            }
+
+            if ($track->containsTag('download')) {
+                return $this->redirect($track->getUrl());
+            }
         }
 
         $this->updateBreadcrumbs($multimediaObject);
 
         $editorChapters = $this->getChapterMarks($multimediaObject);
 
-        return array('autostart' => $request->query->get('autostart', 'true'),
-        'intro' => $this->getIntro($request->query->get('intro')),
-        'multimediaObject' => $multimediaObject,
-        'track' => $track,
-        'editor_chapters' => $editorChapters, );
+        return array(
+            'autostart' => $request->query->get('autostart', 'true'),
+            'intro' => $this->getIntro($request->query->get('intro')),
+            'multimediaObject' => $multimediaObject,
+            'track' => $track,
+            'editor_chapters' => $editorChapters,
+        );
     }
 
     /**

--- a/src/Pumukit/WebTVBundle/Resources/views/MultimediaObject/player.html.twig
+++ b/src/Pumukit/WebTVBundle/Resources/views/MultimediaObject/player.html.twig
@@ -10,7 +10,7 @@ $(window).resize(function(){
 </script>
 {% if magic_url is defined and magic_url %}
   {% set url_iframe = path('pumukit_videoplayer_magicindex', {'secret':multimediaObject.secret, 'autostart': autostart})%}
-{% elseif track is defined %}
+{% elseif track is defined and track %}
   {% set url_iframe = path('pumukit_videoplayer_index', {'id':multimediaObject.id, 'track_id':track.id, 'autostart': autostart}) %}
 {% else %}
   {% set url_iframe = path('pumukit_videoplayer_index', {'id':multimediaObject.id, 'autostart': autostart}) %}


### PR DESCRIPTION
teltek/PuMuKIT2-paella-player-bundle@f28cde54

This change made possible to select one single track from an Opencast video. However, since the WebTVBundle would always set a track, this had the undesirable effect of ALWAYS should only one track.