### PR TITLE
TTK-13965 WebTVBundle: Sent extra request parameters to player iframe

### DIFF
--- a/src/Pumukit/WebTVBundle/Resources/views/MultimediaObject/player.html.twig
+++ b/src/Pumukit/WebTVBundle/Resources/views/MultimediaObject/player.html.twig
@@ -8,13 +8,19 @@ $(window).resize(function(){
     resizeFrame($('#paellaiframe'));
 });
 </script>
+
+{% set iframe_route = 'pumukit_videoplayer_index' %}
+{% set iframe_parameters = {'id':multimediaObject.id, 'autostart': autostart} | merge(app.request.query.all) %}
+
 {% if magic_url is defined and magic_url %}
-  {% set url_iframe = path('pumukit_videoplayer_magicindex', {'secret':multimediaObject.secret, 'autostart': autostart})%}
+  {% set iframe_route = 'pumukit_videoplayer_magicindex' %}
+  {% set iframe_parameters = {'secret':multimediaObject.secret, 'autostart': autostart} | merge(app.request.query.all) %} {# Does adding the id as well break anything? If not, do a merge of secret instead#}
 {% elseif track is defined and track %}
-  {% set url_iframe = path('pumukit_videoplayer_index', {'id':multimediaObject.id, 'track_id':track.id, 'autostart': autostart}) %}
-{% else %}
-  {% set url_iframe = path('pumukit_videoplayer_index', {'id':multimediaObject.id, 'autostart': autostart}) %}
+  {% set iframe_parameters = iframe_parameters | merge({'track_id':track.id}) %}
 {% endif %}
+
+{% set url_iframe = path(iframe_route, iframe_parameters) %}
+
 <iframe src="{{ url_iframe|raw }}"
         id="paellaiframe"
         frameborder="0"


### PR DESCRIPTION
This change is required for https://github.com/teltek/PuMuKIT2-paella-player-bundle/pull/25 to work. Since it is generic, it may help with other future changes to the players.

Note: In: 
    src/Pumukit/WebTVBundle/Resources/views/MultimediaObject/player.html.twig
line 17 I did:
```
{% set iframe_parameters = {'secret':multimediaObject.secret, 'autostart': autostart} | merge(app.request.query.all) %}
```
I would like to do instead:
```
{% set iframe_parameters = iframe_parameters | merge({'secret':multimediaObject.secret}) %}
```
but that would mean the magic url would also have the multimedia object id. Since that could interact with the annotations and I can't test it properly right now, I used the more conservative approach, but it would be nice to change it.