### PR TITLE
TTK-13840 First step to fix user/group services API

### DIFF
--- a/src/Pumukit/SchemaBundle/Services/GroupService.php
+++ b/src/Pumukit/SchemaBundle/Services/GroupService.php
@@ -101,9 +101,9 @@ class GroupService
      * @param Group $group
      * @param bool  $executeFlush
      */
-    public function delete(Group $group, $executeFlush = true)
+    public function delete(Group $group, $executeFlush = true, $checkOrigin = true)
     {
-        if (!$this->canBeDeleted($group)) {
+        if (!$this->canBeDeleted($group, $checkOrigin)) {
             throw new \Exception('Not allowed to delete Group "'.$group->getKey().'": is external Group and/or has existent relations with users and multimedia objects.');
         }
         $this->dm->remove($group);
@@ -121,9 +121,9 @@ class GroupService
      *
      * @return bool
      */
-    public function canBeDeleted(Group $group)
+    public function canBeDeleted(Group $group, $checkOrigin = true)
     {
-        if (!$group->isLocal()) {
+        if ($checkOrigin && !$group->isLocal()) {
             return false;
         }
         if (0 < $this->countUsersInGroup($group)) {


### PR DESCRIPTION
Fix `GroupService::delete` always check the origin.

Original state:

   GroupService::update - not check origin
   GroupService::delete - check origin always
   UserService::update - check origin
   UserService::delete - not check origin
   UserService::addGroup - check origin
   UserService::deleteGroup - check origin