### PR TITLE
TTK-14607: A11Y - Fix H57 errors - lang attribute in html tag

### DIFF
--- a/src/Pumukit/Legacy/WebTVBundle/Resources/views/layout.html.twig
+++ b/src/Pumukit/Legacy/WebTVBundle/Resources/views/layout.html.twig
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="{% block html_class %}{% endblock %}">
+<html class="{% block html_class %}{% endblock %}" lang="{{ app.request.getLocale() }}">
     <head>
         {% block meta %}
         <meta charset="UTF-8" />

--- a/src/Pumukit/WebTVBundle/Resources/views/Layout/base.html.twig
+++ b/src/Pumukit/WebTVBundle/Resources/views/Layout/base.html.twig
@@ -1,5 +1,5 @@
 <!doctype html>
-<html class="{% block html_class %}{% endblock %}" lang="en">
+<html class="{% block html_class %}{% endblock %}" lang="{{ app.request.getLocale() }}">
   <head>
     {% block meta %}
       <meta name="viewport" content="initial-scale=1">


### PR DESCRIPTION
This fixes the use of language attributes on the html element.
https://www.w3.org/TR/WCAG20-TECHS/H57.html