### PR TITLE
TTK-14869 Add itunes:image tag into podcast item

### DIFF
--- a/src/Pumukit/PodcastBundle/Controller/FeedController.php
+++ b/src/Pumukit/PodcastBundle/Controller/FeedController.php
@@ -272,6 +272,7 @@ class FeedController extends Controller
                 $item->addChild('itunes:author', $multimediaObject->getCopyright(), self::ITUNES_DTD_URL);
                 $item->addChild('itunes:keywords', $multimediaObject->getKeyword(), self::ITUNES_DTD_URL);
                 $item->addChild('itunes:explicit', $values['itunes_explicit'], self::ITUNES_DTD_URL);
+                $item->addChild('itunes:image', $this->getAbsoluteUrl($multimediaObject->getFirstUrlPic()), self::ITUNES_DTD_URL);
                 $item->addChild('pubDate', $multimediaObject->getRecordDate()->format('r'));
             }
             $dm->clear();


### PR DESCRIPTION
Non standard solution copied from ondacero:
http://www.ondacero.es/rss/podcast/8502/podcast.xml