### PR TITLE
TTK-15075 Fix activate CPU

### DIFF
--- a/src/Pumukit/EncoderBundle/Resources/views/Info/cpus.html.twig
+++ b/src/Pumukit/EncoderBundle/Resources/views/Info/cpus.html.twig
@@ -26,7 +26,7 @@
       </div>
     </div>
     <script>
-     $('#maintenance-{{name}}-toggle').click(function(){
+     $(document.getElementById('maintenance-{{name}}-toggle')).click(function(){
          var url = '';
          var activateUrl = '{{ path('pumukit_encoder_cpu_maintenance_switch', { 'activateMaintenance': 'activate' , 'cpuName': name} ) }}';
          var deactivateUrl = '{{ path('pumukit_encoder_cpu_maintenance_switch', { 'activateMaintenance': 'deactivate' , 'cpuName': name} ) }}';


### PR DESCRIPTION
Activate CPU fails if their name has a dot char.

```
$('#maintenance-pre_transco.pmk.es-toggle').click(...
```