### PR TITLE
TTK-15273 WebTVBundle: Fixed 'nowrap' for series subtitles

### DIFF
--- a/src/Pumukit/WebTVBundle/Resources/views/Misc/series.html.twig
+++ b/src/Pumukit/WebTVBundle/Resources/views/Misc/series.html.twig
@@ -18,7 +18,7 @@
           <div class="title">
             {{object.title | default('No title')|trans}}
           </div>
-          <div class="serial_title">
+          <div class="subtitle">
             <abbr title="{{object.title}}">
               {{object.line2}}
             </abbr>


### PR DESCRIPTION
Renaming the section to 'subtitle' makes it equal to the mmobj template, so it's css is also applied here.
I found that better than to duplicate the css

**Note:** Merge upwards (2.3.x, ...)