### PR TITLE
TTK-15275 WebTVBundle: Replaced incorrect uses of "publicDate"

### DIFF
--- a/src/Pumukit/WebTVBundle/Resources/views/Misc/miniMultimediaObjects.html.twig
+++ b/src/Pumukit/WebTVBundle/Resources/views/Misc/miniMultimediaObjects.html.twig
@@ -21,7 +21,7 @@
               <small>{{ multimediaObject.getSubtitle() }}</small>
             </div>
             <div class="pull-left date">
-              <small>{{ multimediaObject.publicDate | localizeddate('full', 'none' , app.request.locale, null,"d/MM/Y" ) }}</small>
+              <small>{{ multimediaObject.recordDate | localizeddate('full', 'none' , app.request.locale, null,"d/MM/Y" ) }}</small>
             </div>
           </div>
         </div>

--- a/src/Pumukit/WebTVBundle/Resources/views/Search/list.html.twig
+++ b/src/Pumukit/WebTVBundle/Resources/views/Search/list.html.twig
@@ -16,7 +16,7 @@
       {% set lastDate = object.getPublicDate()|date("d/m/Y") %}
     {% else %}
       {% include 'PumukitWebTVBundle:Misc:multimediaobject.html.twig' with{ 'cols': number_cols } %}
-      {% set lastDate = object.getPublicDate()|date("d/m/Y") %}
+      {% set lastDate = object.getRecordDate()|date("d/m/Y") %}
     {% endif %}
     {% else %}
     <div class="row text-center">


### PR DESCRIPTION
As far as I know, the "publicDate" is used to list series, while the "recordDate" is used for mmobjs,
this makes sense to me, so I corrected the wrong instances where a mmobj would be listed by their "publicDate"

Merge upwards.