### PR TITLE
TTK-15275 latestUploads: Mmobjs publicDate is shown instead of record…

### DIFF
--- a/src/Pumukit/WebTVBundle/Resources/views/Announces/latestUploadsPager.html.twig
+++ b/src/Pumukit/WebTVBundle/Resources/views/Announces/latestUploadsPager.html.twig
@@ -9,7 +9,7 @@
     {% include 'PumukitWebTVBundle:Misc:series.html.twig' with {'cols': number_cols }%}
   {% else %}
     <!-- Multimedia object -->
-    {% include 'PumukitWebTVBundle:Misc:multimediaobject.html.twig' with {'cols': number_cols }%}
+    {% include 'PumukitWebTVBundle:Misc:multimediaobject.html.twig' with {'cols': number_cols , 'with_publicdate': true}%}
   {% endif %}
 {% endfor %}
 </div>

--- a/src/Pumukit/WebTVBundle/Resources/views/Misc/multimediaobject.html.twig
+++ b/src/Pumukit/WebTVBundle/Resources/views/Misc/multimediaobject.html.twig
@@ -22,7 +22,11 @@
             {% endif %}
           </div>
           <div class="date mmobj">
-            {{object.recordDate|date("d/m/Y")}}
+            {% if with_publicdate is defined and with_publicdate %}
+              {{object.publicDate|date("d/m/Y")}}
+            {% else %}
+              {{object.recordDate|date("d/m/Y")}}
+            {% endif %}
           </div>
         </div>
       </div>


### PR DESCRIPTION
This is tricky.
Normally, a multimedia object is sorted by their `recordingDate`, and the `recordingDate` is normally the most relevant information. But in the `latestUploads` window, the `publicDate` is used instead to sort objects. This causes confusion when a `recordingDate` and a `publicDate` are not the same, like this:
![mas_recientes_pre](https://user-images.githubusercontent.com/11334172/30380814-e4a4b2ca-989a-11e7-83dd-9645b5eb34d2.png)

Because of this, I think it's better to add an option to the multimedia object template to display the `publicDate` instead of the `recordingDate`, and to use that option on the `latestUploads` template.