### PR TITLE
TTK-16670 No language info with only language

### DIFF
--- a/src/Pumukit/NewAdminBundle/Resources/views/Themes/fields.html.twig
+++ b/src/Pumukit/NewAdminBundle/Resources/views/Themes/fields.html.twig
@@ -242,21 +242,31 @@
 {# Pumukit2 Widgets #}
 
 {% block texti18n_widget -%}
-    {%- for locale in form.vars.locales %}
-        <div class="input-group">
-            <input type="text" {{ block('widgeti18n_attributes') }} value="{{ value[locale]|default("") }}" />
-            <span class="input-group-addon">{{ locale }}</span>
-        </div>
-    {%- endfor -%}
+    {%- if form.vars.locales|length == 1%}
+        {% set locale = form.vars.locales[0] %}
+        <input type="text" {{ block('widgeti18n_attributes') }} value="{{ value[locale]|default("") }}" />
+    {% else %}
+        {%- for locale in form.vars.locales %}
+            <div class="input-group">
+                <input type="text" {{ block('widgeti18n_attributes') }} value="{{ value[locale]|default("") }}" />
+                <span class="input-group-addon">{{ locale }}</span>
+            </div>
+        {% endfor -%}
+    {% endif -%}
 {%- endblock texti18n_widget %}
 
 {% block textareai18n_widget -%}
-    {%- for locale in form.vars.locales %}
-        <div class="input-group">
-            <textarea {{ block('widgeti18n_attributes') }}>{{ value[locale]|default("") }}</textarea>
-            <span class="input-group-addon">{{ locale }}</span>
-        </div>
-    {%- endfor -%}
+    {%- if form.vars.locales|length == 1 %}
+        {% set locale = form.vars.locales[0] %}
+        <textarea {{ block('widgeti18n_attributes') }}>{{ value[locale]|default("") }}</textarea>
+  {% else %}
+      {%- for locale in form.vars.locales %}
+          <div class="input-group">
+              <textarea {{ block('widgeti18n_attributes') }}>{{ value[locale]|default("") }}</textarea>
+              <span class="input-group-addon">{{ locale }}</span>
+          </div>
+      {%- endfor -%}
+    {% endif -%}
 {%- endblock textareai18n_widget %}
 
 {% block widgeti18n_attributes -%}


### PR DESCRIPTION
Current behavior:

  * Two languages:

![screenshot-2018-1-16 pumukit2 admin 1](https://user-images.githubusercontent.com/195745/34986838-604186b2-fab9-11e7-9e08-816a7360ce77.png)

 * One language:

![screenshot-2018-1-16 pumukit2 admin 2](https://user-images.githubusercontent.com/195745/34986862-7912270a-fab9-11e7-8f55-7d615a6e73fe.png)

Change proposal:

  * Two languages: No changes
 * One language:

![screenshot-2018-1-16 pumukit2 admin 3](https://user-images.githubusercontent.com/195745/34986915-ab440bc6-fab9-11e7-9aee-9bca60281a56.png)



