### PR TITLE
TTK-16693: Fix is user allow to delete series when user has personal …

### DIFF
--- a/src/Pumukit/NewAdminBundle/Controller/SeriesController.php
+++ b/src/Pumukit/NewAdminBundle/Controller/SeriesController.php
@@ -521,7 +521,7 @@ class SeriesController extends AdminController implements NewAdminController
     /**
      * Returns true if the user has enough permissions to delete the $resource passed
      *
-     * This function will always return true if the user the MODIFY_ONWER permission. Otherwise,
+     * This function will always return true if the user has the MODIFY_ONWER permission. Otherwise,
      * it checks if it is the owner of the object (and there are no other owners) and returns false if not.
      * Since this is a series, that means it will check every object for ownerships.
      */
@@ -534,15 +534,18 @@ class SeriesController extends AdminController implements NewAdminController
             $role = $personService->getPersonalScopeRole();
             if(!$person)
                 return false;
-            $mmobjRepo = $this->get('doctrine_mongodb.odm.document_manager')
-                              ->getRepository('PumukitSchemaBundle:MultimediaObject');
+            $dm = $this->get('doctrine_mongodb.odm.document_manager');
+            $filter = $dm->getFilterCollection()->disable('backoffice');
+            $mmobjRepo = $dm->getRepository('PumukitSchemaBundle:MultimediaObject');
             $allMmobjs = $mmobjRepo->createStandardQueryBuilder()->field('series')->equals($series->getId())->getQuery()->execute();
             foreach($allMmobjs as $resource) {
                 if(!$resource->containsPersonWithRole($person, $role) ||
                    count($resource->getPeopleByRole($role, true)) > 1) {
+                    $filter = $dm->getFilterCollection()->enable('backoffice');
                     return false;
                 }
             }
+            $filter = $dm->getFilterCollection()->enable('backoffice');
         }
         return true;
     }


### PR DESCRIPTION
…scope

Problem:
* Given a series created by an user with global or personal scope.
* This user adds another user with personal scope to the list of owners of the series.
* Both users create multimedia objects inside this series.
* In the backoffice there is a filter activated, so the user with personal scope only sees his/her videos.
* When removing a series, the controller deletes all of this user videos and the template of the series. The rest of the multimedia objects of this series are left orphans without series in the database.

Solution:

* Disable the backoffice filter before checking if the user is allowed to remove the series.
* Enable it afterwards.