### PR TITLE
Fix travis (pa11y error)

### DIFF
--- a/.pa11y.json
+++ b/.pa11y.json
@@ -1,0 +1,10 @@
+{
+    allowedStandards: 'WCAG2AA',
+    level: 'error',
+    chromeLaunchConfig: {
+        args: [
+            '--no-sandbox',
+            '--disable-setuid-sandbox'
+        ]
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,14 +45,14 @@ script:
     - php app/console pumukit:init:repo all --force
 #    - php app/console pumukit:init:example  --force
     - php app/console server:start --env=prod
-    - pa11y -l error -s WCAG2AA -r cli http://localhost:8000/
-    - pa11y -l error -s WCAG2AA -r cli http://localhost:8000/series/channel/1.html
-    - pa11y -l error -s WCAG2AA -r cli http://localhost:8000/latestuploads
-    - pa11y -l error -s WCAG2AA -r cli http://localhost:8000/searchmultimediaobjects
-    - pa11y -l error -s WCAG2AA -r cli http://localhost:8000/searchseries
-#    - pa11y -l error -s WCAG2AA -r cli http://localhost:8000/live/595b77640fd60c42008b4567
-    - pa11y -l error -s WCAG2AA -r cli http://localhost:8000/mediateca
-    - pa11y -l error -s WCAG2AA -r cli http://localhost:8000/categories
-#    - pa11y -l error -s WCAG2AA -r cli http://localhost:8000/video/59269ab79833a041008b4576
-#    - pa11y -l error -s WCAG2AA -r cli http://localhost:8000/series/5925a5519833a043008b456c
+    - pa11y -c .pa11y.json http://localhost:8000/
+    - pa11y -c .pa11y.json http://localhost:8000/series/channel/1.html
+    - pa11y -c .pa11y.json http://localhost:8000/latestuploads
+    - pa11y -c .pa11y.json http://localhost:8000/searchmultimediaobjects
+    - pa11y -c .pa11y.json http://localhost:8000/searchseries
+#    - pa11y -c .pa11y.json http://localhost:8000/live/595b77640fd60c42008b4567
+    - pa11y -c .pa11y.json http://localhost:8000/mediateca
+    - pa11y -c .pa11y.json http://localhost:8000/categories
+#    - pa11y -c .pa11y.json http://localhost:8000/video/59269ab79833a041008b4576
+#    - pa11y -c .pa11y.json http://localhost:8000/series/5925a5519833a043008b456c
     - php app/console server:stop


### PR DESCRIPTION
$ pa11y -l error -s WCAG2AA -r cli http://localhost:8000/
Welcome to Pa11y
 > Running Pa11y on URL http://localhost:8000/
Error: Failed to launch chrome!
[0222/125121.779468:FATAL:zygote_host_impl_linux.cc(124)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/master/docs/linux_suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
#0 0x55addc0ef8ec base::debug::StackTrace::StackTrace()
#1 0x55addc107770 logging::LogMessage::~LogMessage()
#2 0x55addb1c1f61 content::ZygoteHostImpl::Init()
#3 0x55addae3c3b5 content::BrowserMainLoop::EarlyInitialization()
#4 0x55addae4230a content::BrowserMainRunnerImpl::Initialize()
#5 0x55ade00a98f8 headless::HeadlessContentMainDelegate::RunProcess()
#6 0x55addbe29160 content::RunNamedProcessTypeMain()
#7 0x55addbe29ab6 content::ContentMainRunnerImpl::Run()
#8 0x55addbe32d59 service_manager::Main()
#9 0x55addbe28661 content::ContentMain()
#10 0x55ade00a89f8 headless::(anonymous namespace)::RunContentMain()
#11 0x55ade00a8a6e headless::HeadlessBrowserMain()
#12 0x55addbe2fc49 headless::HeadlessShellMain()
#13 0x55adda6df1c4 ChromeMain
#14 0x7f137eb8ef45 __libc_start_main
#15 0x55adda6df02a _start
Received signal 6
#0 0x55addc0ef8ec base::debug::StackTrace::StackTrace()
#1 0x55addc0ef451 base::debug::(anonymous namespace)::StackDumpSignalHandler()
#2 0x7f1384818330 <unknown>
#3 0x7f137eba3c37 gsignal
#4 0x7f137eba7028 abort
#5 0x55addc0edee5 base::debug::BreakDebugger()
#6 0x55addc107bbb logging::LogMessage::~LogMessage()
#7 0x55addb1c1f61 content::ZygoteHostImpl::Init()
#8 0x55addae3c3b5 content::BrowserMainLoop::EarlyInitialization()
#9 0x55addae4230a content::BrowserMainRunnerImpl::Initialize()
#10 0x55ade00a98f8 headless::HeadlessContentMainDelegate::RunProcess()
#11 0x55addbe29160 content::RunNamedProcessTypeMain()
#12 0x55addbe29ab6 content::ContentMainRunnerImpl::Run()
#13 0x55addbe32d59 service_manager::Main()
#14 0x55addbe28661 content::ContentMain()
#15 0x55ade00a89f8 headless::(anonymous namespace)::RunContentMain()
#16 0x55ade00a8a6e headless::HeadlessBrowserMain()
#17 0x55addbe2fc49 headless::HeadlessShellMain()
#18 0x55adda6df1c4 ChromeMain
#19 0x7f137eb8ef45 __libc_start_main
#20 0x55adda6df02a _start
  r8: 00007f1384c10a00  r9: 000023ee9ac42800 r10: 0000000000000008 r11: 0000000000000206
 r12: 00007ffe72bd2038 r13: 0000000000000161 r14: 00007ffe72bd2040 r15: 00007ffe72bd1bd9
  di: 000000000000a4c6  si: 000000000000a4c6  bp: 00007ffe72bd1b80  bx: 00007ffe72bd1bf0
  dx: 0000000000000006  ax: 0000000000000000  cx: 00007f137eba3c37  sp: 00007ffe72bd1a48
  ip: 00007f137eba3c37 efl: 0000000000000206 cgf: 002b000000000033 erf: 0000000000000000
 trp: 0000000000000000 msk: 0000000000000000 cr2: 0000000000000000
[end of stack trace]
Calling _exit(1). Core file will not be generated.
TROUBLESHOOTING: https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md
    at onClose (/home/travis/.nvm/versions/node/v8.9.1/lib/node_modules/pa11y/node_modules/puppeteer/lib/Launcher.js:235:14)
    at Interface.helper.addEventListener (/home/travis/.nvm/versions/node/v8.9.1/lib/node_modules/pa11y/node_modules/puppeteer/lib/Launcher.js:224:50)
    at emitNone (events.js:111:20)
    at Interface.emit (events.js:208:7)
    at Interface.close (readline.js:370:8)
    at Socket.onend (readline.js:149:10)
    at emitNone (events.js:111:20)
    at Socket.emit (events.js:208:7)
    at endReadableNT (_stream_readable.js:1056:12)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)