### PR TITLE
TTK-17299 Performance: Add AjaxSessionCloseListener

### DIFF
--- a/src/Pumukit/CoreBundle/EventListener/AjaxSessionCloseListener.php
+++ b/src/Pumukit/CoreBundle/EventListener/AjaxSessionCloseListener.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Pumukit\CoreBundle\EventListener;
+
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+
+/**
+ * See: https://tideways.io/profiler/blog/slow-ajax-requests-in-your-symfony-application-apply-this-simple-fix.
+ */
+class AjaxSessionCloseListener
+{
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $request = $event->getRequest();
+
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        if (!$request->isXmlHttpRequest()) {
+            return;
+        }
+
+        if (!$request->attributes->has('_route')) {
+            return;
+        }
+
+        $session = $request->getSession();
+        $session->save();
+    }
+}

--- a/src/Pumukit/CoreBundle/Resources/config/services.xml
+++ b/src/Pumukit/CoreBundle/Resources/config/services.xml
@@ -8,7 +8,9 @@
     <service id="twig.extension.intl" class="Twig_Extensions_Extension_Intl">
       <tag name="twig.extension" />
     </service>
-
+    <service id="pumukitcore.ajax_session_close_listener" class="Pumukit\CoreBundle\EventListener\AjaxSessionCloseListener">
+      <tag name="kernel.event_listener" event="kernel.request" priority="-255" />
+    </service>
     <service id="pumukitcore.filter" class="Pumukit\CoreBundle\EventListener\FilterListener">
       <argument type="service" id="doctrine_mongodb.odm.document_manager" />
       <argument type="service" id="pumukitschema.person"/>

--- a/src/Pumukit/NewAdminBundle/Controller/AdminController.php
+++ b/src/Pumukit/NewAdminBundle/Controller/AdminController.php
@@ -153,8 +153,6 @@ class AdminController extends ResourceController implements NewAdminController
         $config = $this->getConfiguration();
         $data = $this->findOr404($request);
 
-        $this->get('session')->set('admin/'.$config->getResourceName().'/id', $data->getId());
-
         $view = $this
             ->view()
             ->setTemplate($config->getTemplate('show.html'))

--- a/src/Pumukit/NewAdminBundle/Controller/MultimediaObjectController.php
+++ b/src/Pumukit/NewAdminBundle/Controller/MultimediaObjectController.php
@@ -138,8 +138,6 @@ class MultimediaObjectController extends SortableAdminController implements NewA
         $config = $this->getConfiguration();
         $data = $this->findOr404($request);
 
-        $this->get('session')->set('admin/mms/id', $data->getId());
-
         $activeEditor = $this->checkHasEditor();
 
         return array(

--- a/src/Pumukit/NewAdminBundle/Controller/UNESCOController.php
+++ b/src/Pumukit/NewAdminBundle/Controller/UNESCOController.php
@@ -432,9 +432,6 @@ class UNESCOController extends Controller implements NewAdminController
             $multimediaObject = $dm->getRepository('PumukitSchemaBundle:MultimediaObject')->findOneBy(
                 array('_id' => new \MongoId($id))
             );
-            if ($multimediaObject) {
-                $this->get('session')->set('admin/unesco/id', $multimediaObject->getId());
-            }
         } else {
             $multimediaObject = null;
         }


### PR DESCRIPTION
By default only one request can execute synchronously per session at the
same time. Other requests for the same session will wait inside the
session_start() call until the previous requests are finished. This
commit fixes that multiple concurrent Ajax requests will wait for each other
and making the application much slower than it must be.

https://tideways.io/profiler/blog/slow-ajax-requests-in-your-symfony-application-apply-this-simple-fix