### PR TITLE
PHP7 Fix using True as class name as it is reserved

### DIFF
--- a/src/Pumukit/LiveBundle/Document/Live.php
+++ b/src/Pumukit/LiveBundle/Document/Live.php
@@ -191,7 +191,7 @@ class Live
     }
 
     /**
-     * @Assert\True(message = "Live type not valid")
+     * @Assert\IsTrue(message = "Live type not valid")
      */
     public function isValidLiveType()
     {

--- a/src/Pumukit/SchemaBundle/Document/Broadcast.php
+++ b/src/Pumukit/SchemaBundle/Document/Broadcast.php
@@ -328,7 +328,7 @@ class Broadcast
     }
 
     /**
-     * @Assert\True(message = "Password required if not public")
+     * @Assert\IsTrue(message = "Password required if not public")
      */
     public function isPasswordValid()
     {

--- a/src/Pumukit/SchemaBundle/Document/EmbeddedBroadcast.php
+++ b/src/Pumukit/SchemaBundle/Document/EmbeddedBroadcast.php
@@ -204,7 +204,7 @@ class EmbeddedBroadcast
     }
 
     /**
-     * @Assert\True(message = "Password required if not public")
+     * @Assert\IsTrue(message = "Password required if not public")
      */
     public function isPasswordValid()
     {


### PR DESCRIPTION
Fixes:

> The `Symfony\Component\Validator\Constraints\True` class is deprecated since version 2.7 and will be removed in 3.0. Use the `IsTrue` class in the same namespace instead.