### PR TITLE
PHP7 Cannot use ODM annotations as class name as it is reserved.

### DIFF
--- a/src/Pumukit/EncoderBundle/Document/CpuStatus.php
+++ b/src/Pumukit/EncoderBundle/Document/CpuStatus.php
@@ -34,14 +34,14 @@ class CpuStatus
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $name;
 
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      */
     private $status = self::STATUS_WORKING;
 

--- a/src/Pumukit/EncoderBundle/Document/Job.php
+++ b/src/Pumukit/EncoderBundle/Document/Job.php
@@ -44,7 +44,7 @@ class Job
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      * @MongoDB\Index
      */
     private $mm_id;
@@ -53,42 +53,42 @@ class Job
      * //@var int $language_id
      * // TODO check this or next
      * // language code instead of integer
-     * //@MongoDB\Int.
+     * //@MongoDB\Field(type="int").
      */
     //private $language_id;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $language_id;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $profile;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $cpu;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $url;
 
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      * @MongoDB\Index
      */
     private $status = self::STATUS_WAITING;
@@ -96,105 +96,105 @@ class Job
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      */
     private $priority;
 
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $name = array('en' => '');
 
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $description = array('en' => '');
 
     /**
      * @var date
      *
-     * @MongoDB\Date
+     * @MongoDB\Field(type="date")
      */
     private $timeini;
 
     /**
      * @var date
      *
-     * @MongoDB\Date
+     * @MongoDB\Field(type="date")
      */
     private $timestart;
 
     /**
      * @var date
      *
-     * @MongoDB\Date
+     * @MongoDB\Field(type="date")
      */
     private $timeend;
 
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      */
     private $pid;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $path_ini;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $path_end;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $ext_ini;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $ext_end;
 
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      */
     private $duration = 0;
 
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      */
     private $new_duration = 0;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $size = '0';
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      * @Assert\Email
      */
     private $email;
@@ -202,14 +202,14 @@ class Job
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $output = '';
 
     /**
      * @var array
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $initVars = array();
 

--- a/src/Pumukit/LiveBundle/Document/Event.php
+++ b/src/Pumukit/LiveBundle/Document/Event.php
@@ -29,49 +29,49 @@ class Event
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $name;
 
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $description = array('en' => '');
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $place;
 
     /**
      * @var datetime
      *
-     * @MongoDB\Date
+     * @MongoDB\Field(type="date")
      */
     private $date;
 
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      */
     private $duration = 60;
 
     /**
      * @var bool
      *
-     * @MongoDB\Boolean
+     * @MongoDB\Field(type="boolean")
      */
     private $display = true;
 
     /**
      * @var bool
      *
-     * @MongoDB\Boolean
+     * @MongoDB\Field(type="boolean")
      */
     private $create_serial = true;
 

--- a/src/Pumukit/LiveBundle/Document/Live.php
+++ b/src/Pumukit/LiveBundle/Document/Live.php
@@ -25,7 +25,7 @@ class Live
 
     /**
      * @var string
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      * @Assert\NotBlank()
      * @Assert\Url(protocols= {"rtmpt", "rtmp", "http", "mms", "rtp", "https"})
      */
@@ -33,75 +33,75 @@ class Live
 
     /**
      * @var string
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $passwd;
 
     /**
      * @var int
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $live_type = self::LIVE_TYPE_WOWZA;
 
     /**
      * @var int
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      */
     private $width = 720;
 
     /**
      * @var int
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      */
     private $height = 576;
 
     /**
      * @var string
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $qualities;
 
     /**
      * @var string
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $ip_source;
 
     /**
      * @var string
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      * @Assert\NotBlank()
      */
     private $source_name;
 
     /**
      * @var bool
-     * @MongoDB\Boolean
+     * @MongoDB\Field(type="boolean")
      */
     private $index_play = false;
 
     /**
      * @var bool
-     * @MongoDB\Boolean
+     * @MongoDB\Field(type="boolean")
      */
     private $broadcasting = false;
 
     /**
      * @var bool
-     * @MongoDB\Boolean
+     * @MongoDB\Field(type="boolean")
      */
     private $debug = false;
 
     /**
      * @var string
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      * @Assert\NotBlank()
      */
     private $name = array('en' => '');
 
     /**
      * @var string
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $description = array('en' => '');
 

--- a/src/Pumukit/LiveBundle/Document/Message.php
+++ b/src/Pumukit/LiveBundle/Document/Message.php
@@ -20,7 +20,7 @@ class Message
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $author;
 
@@ -34,21 +34,21 @@ class Message
     /**
      * @var string message
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $message;
 
     /**
      * @var \DateTime
      *
-     * @MongoDB\Date
+     * @MongoDB\Field(type="date")
      */
     private $insertDate;
 
     /**
      * @var string cookie
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $cookie;
 

--- a/src/Pumukit/SchemaBundle/Document/Annotation.php
+++ b/src/Pumukit/SchemaBundle/Document/Annotation.php
@@ -21,7 +21,7 @@ class Annotation
     /**
      * @var object_id
      *
-     * @MongoDB\ObjectId
+     * @MongoDB\Field(type="object_id")
      */
     //This field would be the equivalent to 'mediapackage_id' on opencast.
     private $multimediaObject;
@@ -29,63 +29,63 @@ class Annotation
     /**
      * @var date
      *
-     * @MongoDB\Date
+     * @MongoDB\Field(type="date")
      */
     private $created;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $type;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $user_id;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $session;
 
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      */
     private $inpoint;
 
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      */
     private $outpoint;
 
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      */
     private $length;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $value;
 
     /**
      * @var bool
      *
-     * @MongoDB\Boolean
+     * @MongoDB\Field(type="boolean")
      */
     private $is_private;
 

--- a/src/Pumukit/SchemaBundle/Document/Broadcast.php
+++ b/src/Pumukit/SchemaBundle/Document/Broadcast.php
@@ -38,7 +38,7 @@ class Broadcast
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      * @MongoDB\Increment
      */
     private $number_multimedia_objects = 0;
@@ -46,7 +46,7 @@ class Broadcast
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      * @MongoDB\UniqueIndex(safe=1)
      */
     private $name;
@@ -54,28 +54,28 @@ class Broadcast
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $broadcast_type_id = self::BROADCAST_TYPE_PUB;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $passwd;
 
     /**
      * @var bool
      *
-     * @MongoDB\Boolean
+     * @MongoDB\Field(type="boolean")
      */
     private $default_sel = false;
 
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $description = array('en' => '');
 

--- a/src/Pumukit/SchemaBundle/Document/Comments.php
+++ b/src/Pumukit/SchemaBundle/Document/Comments.php
@@ -21,21 +21,21 @@ class Comments
     /**
      * @var \Date
      *
-     * @MongoDB\Date
+     * @MongoDB\Field(type="date")
      */
     private $date;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $text;
 
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      * @MongoDB\EmbedOne(targetDocument="MultimediaObject")
      */
     private $multimedia_object_id;
@@ -53,7 +53,7 @@ class Comments
     /**
      * Set date.
      *
-     * @param @MongoDB\Date $date
+     * @param @MongoDB\Field(type="date") $date
      *
      * @return Comments
      */
@@ -67,7 +67,7 @@ class Comments
     /**
      * Get date.
      *
-     * @return @MongoDB\Date
+     * @return @MongoDB\Field(type="date")
      */
     public function getDate()
     {

--- a/src/Pumukit/SchemaBundle/Document/Element.php
+++ b/src/Pumukit/SchemaBundle/Document/Element.php
@@ -29,49 +29,49 @@ class Element
     /**
      * @var array
      *
-     * @MongoDB\Collection
+     * @MongoDB\Field(type="collection")
      */
     private $tags;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $url;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $path;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $mime_type;
 
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      */
     private $size;
 
     /**
      * @var bool
      *
-     * @MongoDB\Boolean
+     * @MongoDB\Field(type="boolean")
      */
     private $hide = false;
 
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $description = array('en' => '');
 

--- a/src/Pumukit/SchemaBundle/Document/EmbeddedBroadcast.php
+++ b/src/Pumukit/SchemaBundle/Document/EmbeddedBroadcast.php
@@ -33,21 +33,21 @@ class EmbeddedBroadcast
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $name = self::NAME_PUBLIC;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $type = self::TYPE_PUBLIC;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $password;
 

--- a/src/Pumukit/SchemaBundle/Document/EmbeddedEvent.php
+++ b/src/Pumukit/SchemaBundle/Document/EmbeddedEvent.php
@@ -22,55 +22,55 @@ class EmbeddedEvent
 
     /**
      * @var string
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $name;
 
     /**
      * @var string
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $description;
 
     /**
      * @var string
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $author;
 
     /**
      * @var string
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $producer;
 
     /**
      * @var string
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $place;
 
     /**
      * @var \Datetime
-     * @MongoDB\Date
+     * @MongoDB\Field(type="date")
      */
     private $date;
 
     /**
      * @var int
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      */
     private $duration;
 
     /**
      * @var bool
-     * @MongoDB\Boolean
+     * @MongoDB\Field(type="boolean")
      */
     private $display = true;
 
     /**
      * @var bool
-     * @MongoDB\Boolean
+     * @MongoDB\Field(type="boolean")
      */
     private $create_serial = true;
 
@@ -88,7 +88,7 @@ class EmbeddedEvent
 
     /**
      * @var string
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      * @Assert\NotBlank()
      * @Assert\Url(protocols= {"rtmpt", "rtmp", "http", "mms", "rtp", "https"})
      */
@@ -97,20 +97,20 @@ class EmbeddedEvent
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $alreadyHeldMessage = array('en' => '');
 
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $notYetHeldMessage = array('en' => '');
 
     /**
      * @var bool
-     * @MongoDB\Boolean
+     * @MongoDB\Field(type="boolean")
      */
     private $enableChat = false;
 

--- a/src/Pumukit/SchemaBundle/Document/EmbeddedEventSession.php
+++ b/src/Pumukit/SchemaBundle/Document/EmbeddedEventSession.php
@@ -21,28 +21,28 @@ class EmbeddedEventSession
     /**
      * @var date
      *
-     * @MongoDB\Date
+     * @MongoDB\Field(type="date")
      */
     private $start;
 
     /**
      * @var date
      *
-     * @MongoDB\Date
+     * @MongoDB\Field(type="date")
      */
     private $ends;
 
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      */
     private $duration = 0;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $notes;
 

--- a/src/Pumukit/SchemaBundle/Document/EmbeddedPerson.php
+++ b/src/Pumukit/SchemaBundle/Document/EmbeddedPerson.php
@@ -24,14 +24,14 @@ class EmbeddedPerson
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     protected $name;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      * @Assert\Email
      * //@Assert\NotEmpty
      */
@@ -40,7 +40,7 @@ class EmbeddedPerson
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      * //@Assert\Url('http', 'https', 'ftp')
      */
     protected $web;
@@ -48,35 +48,35 @@ class EmbeddedPerson
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     protected $phone;
 
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     protected $honorific = array('en' => '');
 
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     protected $firm = array('en' => '');
 
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     protected $post = array('en' => '');
 
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     protected $bio = array('en' => '');
 

--- a/src/Pumukit/SchemaBundle/Document/EmbeddedRole.php
+++ b/src/Pumukit/SchemaBundle/Document/EmbeddedRole.php
@@ -22,7 +22,7 @@ class EmbeddedRole
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $cod = '0';
 
@@ -31,28 +31,28 @@ class EmbeddedRole
      *
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $xml;
 
     /**
      * @var bool
      *
-     * @MongoDB\Boolean
+     * @MongoDB\Field(type="boolean")
      */
     private $display = true;
 
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $name = array('en' => '');
 
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $text = array('en' => '');
 

--- a/src/Pumukit/SchemaBundle/Document/EmbeddedSocial.php
+++ b/src/Pumukit/SchemaBundle/Document/EmbeddedSocial.php
@@ -19,19 +19,19 @@ class EmbeddedSocial
 
     /**
      * @var string
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $twitter;
 
     /**
      * @var string
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $twitterHashtag;
 
     /**
      * @var string
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $email;
 

--- a/src/Pumukit/SchemaBundle/Document/EmbeddedTag.php
+++ b/src/Pumukit/SchemaBundle/Document/EmbeddedTag.php
@@ -21,28 +21,28 @@ class EmbeddedTag
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $title = array('en' => '');
 
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $description = array('en' => '');
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $slug;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      * @MongoDB\Index
      */
     private $cod = '';
@@ -50,14 +50,14 @@ class EmbeddedTag
     /**
      * @var bool
      *
-     * @MongoDB\Boolean
+     * @MongoDB\Field(type="boolean")
      */
     private $metatag = false;
 
     /**
      * @var bool
      *
-     * @MongoDB\Boolean
+     * @MongoDB\Field(type="boolean")
      */
     private $display = false;
 
@@ -72,14 +72,14 @@ class EmbeddedTag
     /**
      * @var date
      *
-     * @MongoDB\Date
+     * @MongoDB\Field(type="date")
      */
     private $created;
 
     /**
      * @var date
      *
-     * @MongoDB\Date
+     * @MongoDB\Field(type="date")
      */
     private $updated;
 

--- a/src/Pumukit/SchemaBundle/Document/Group.php
+++ b/src/Pumukit/SchemaBundle/Document/Group.php
@@ -25,7 +25,7 @@ class Group implements GroupInterface
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      * @MongoDB\UniqueIndex(order="asc")
      * @Assert\Regex("/^\w*$/")
      */
@@ -34,7 +34,7 @@ class Group implements GroupInterface
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      * @MongoDB\UniqueIndex(order="asc")
      */
     protected $name;
@@ -42,28 +42,28 @@ class Group implements GroupInterface
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     protected $comments;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     protected $origin = self::ORIGIN_LOCAL;
 
     /**
      * @var date
      *
-     * @MongoDB\Date
+     * @MongoDB\Field(type="date")
      */
     private $createdAt;
 
     /**
      * @var date
      *
-     * @MongoDB\Date
+     * @MongoDB\Field(type="date")
      */
     private $updatedAt;
 

--- a/src/Pumukit/SchemaBundle/Document/Link.php
+++ b/src/Pumukit/SchemaBundle/Document/Link.php
@@ -13,7 +13,7 @@ class Link extends Element
 {
     /**
      * @var array
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $name = array('en' => '');
 

--- a/src/Pumukit/SchemaBundle/Document/Material.php
+++ b/src/Pumukit/SchemaBundle/Document/Material.php
@@ -13,13 +13,13 @@ class Material extends Element
 {
     /**
      * @var array
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $name = array('en' => '');
 
     /**
      * @var string
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $language;
 

--- a/src/Pumukit/SchemaBundle/Document/MultimediaObject.php
+++ b/src/Pumukit/SchemaBundle/Document/MultimediaObject.php
@@ -56,14 +56,14 @@ class MultimediaObject
 
     /**
      * @var int
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      * @MongoDB\Index
      */
     private $type;
 
     /**
      * @var string
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      * @MongoDB\Index
      */
     private $secret;
@@ -80,7 +80,7 @@ class MultimediaObject
      *       Do not use this field and do not create setter and/or getter.
      *
      * @var string
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $seriesTitle = array('en' => '');
 
@@ -131,82 +131,82 @@ class MultimediaObject
 
     /**
      * @var int
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      * @Gedmo\SortablePosition
      */
     private $rank;
 
     /**
      * @var int
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      */
     private $status = self::STATUS_NEW;
 
     /**
      * @var date
-     * @MongoDB\Date
+     * @MongoDB\Field(type="date")
      * @MongoDB\Index
      */
     private $record_date;
 
     /**
      * @var date
-     * @MongoDB\Date
+     * @MongoDB\Field(type="date")
      * @MongoDB\Index
      */
     private $public_date;
 
     /**
      * @var array
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $title = array('en' => '');
 
     /**
      * @var string
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $subtitle = array('en' => '');
 
     /**
      * @var array
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $description = array('en' => '');
 
     /**
      * @var string
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $comments;
 
     /**
      * @var array
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $line2 = array('en' => '');
 
     /**
      * @var string
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $copyright;
 
     /**
      * @var string
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $license;
 
     /**
      * @var int
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      */
     private $duration = 0;
 
     /**
      * @var int
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      * @MongoDB\Increment
      */
     private $numview = 0;

--- a/src/Pumukit/SchemaBundle/Document/PermissionProfile.php
+++ b/src/Pumukit/SchemaBundle/Document/PermissionProfile.php
@@ -15,10 +15,10 @@ class PermissionProfile
     const SCOPE_NONE = 'ROLE_SCOPE_NONE';
 
     public static $scopeDescription = array(
-                                            self::SCOPE_GLOBAL => 'Global Scope',
-                                            self::SCOPE_PERSONAL => 'Personal Scope',
-                                            self::SCOPE_NONE => 'No Scope',
-                                            );
+        self::SCOPE_GLOBAL => 'Global Scope',
+        self::SCOPE_PERSONAL => 'Personal Scope',
+        self::SCOPE_NONE => 'No Scope',
+    );
 
     /**
      * @var string
@@ -30,7 +30,7 @@ class PermissionProfile
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      * @MongoDB\UniqueIndex(order="asc")
      */
     private $name = '';
@@ -38,35 +38,35 @@ class PermissionProfile
     /**
      * @var array
      *
-     * @MongoDB\Collection
+     * @MongoDB\Field(type="collection")
      */
     private $permissions = array();
 
     /**
      * @var bool
      *
-     * @MongoDB\Boolean
+     * @MongoDB\Field(type="boolean")
      */
     private $system = false;
 
     /**
      * @var bool
      *
-     * @MongoDB\Boolean
+     * @MongoDB\Field(type="boolean")
      */
     private $default = false;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $scope = self::SCOPE_PERSONAL;
 
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      * @Gedmo\SortablePosition
      */
     private $rank;

--- a/src/Pumukit/SchemaBundle/Document/Person.php
+++ b/src/Pumukit/SchemaBundle/Document/Person.php
@@ -29,14 +29,14 @@ class Person
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     protected $name;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      * @Assert\Email
      */
     protected $email;
@@ -44,7 +44,7 @@ class Person
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      * //@Assert\Url('http', 'https', 'ftp')
      */
     protected $web;
@@ -52,35 +52,35 @@ class Person
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     protected $phone;
 
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     protected $honorific = array('en' => '');
 
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     protected $firm = array('en' => '');
 
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     protected $post = array('en' => '');
 
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     protected $bio = array('en' => '');
 

--- a/src/Pumukit/SchemaBundle/Document/Pic.php
+++ b/src/Pumukit/SchemaBundle/Document/Pic.php
@@ -14,14 +14,14 @@ class Pic extends Element
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      */
     private $width;
 
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      */
     private $height;
 

--- a/src/Pumukit/SchemaBundle/Document/Role.php
+++ b/src/Pumukit/SchemaBundle/Document/Role.php
@@ -18,7 +18,7 @@ class Role
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      * @MongoDB\UniqueIndex(safe=1)
      */
     private $cod = '0';
@@ -26,7 +26,7 @@ class Role
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      * @MongoDB\Index
      * @Gedmo\SortablePosition
      */
@@ -35,7 +35,7 @@ class Role
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      * @MongoDB\Increment
      */
     private $number_people_in_multimedia_object = 0;
@@ -46,35 +46,35 @@ class Role
      *
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $xml;
 
     /**
      * @var bool
      *
-     * @MongoDB\Boolean
+     * @MongoDB\Field(type="boolean")
      */
     private $display = true;
 
     /**
      * @var bool
      *
-     * @MongoDB\Boolean
+     * @MongoDB\Field(type="boolean")
      */
     private $readOnly = false;
 
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $name = array('en' => '');
 
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $text = array('en' => '');
 

--- a/src/Pumukit/SchemaBundle/Document/Series.php
+++ b/src/Pumukit/SchemaBundle/Document/Series.php
@@ -56,7 +56,7 @@ class Series
 
     /**
      * @var string
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      * @MongoDB\Index
      */
     private $secret;
@@ -65,14 +65,14 @@ class Series
      * Flag with TYPE_SERIES or TYPE_PLAYLIST to determine the collection type.
      *
      * @var int
-     * @MongoDB\Integer
+     * @MongoDB\Field(type="int")eger
      * @MongoDB\Index
      */
     private $type;
 
     /**
      * @var int
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      */
     private $sorting = self::SORT_MANUAL;
 
@@ -107,7 +107,7 @@ class Series
 
     /**
      * @var bool
-     * @MongoDB\Boolean
+     * @MongoDB\Field(type="boolean")
      */
     private $announce = false;
 
@@ -117,63 +117,63 @@ class Series
      * and we want to force that the serie will be hide.
      *
      * @var bool
-     * @MongoDB\Boolean
+     * @MongoDB\Field(type="boolean")
      * @MongoDB\Index
      */
     private $hide = true;
 
     /**
      * @var datetime
-     * @MongoDB\Date
+     * @MongoDB\Field(type="date")
      * @MongoDB\Index
      */
     private $public_date;
 
     /**
      * @var string
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $title = array('en' => '');
 
     /**
      * @var string
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $subtitle = array('en' => '');
 
     /**
      * @var text
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $description = array('en' => '');
 
     /**
      * @var text
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $header = array('en' => '');
 
     /**
      * @var text
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $footer = array('en' => '');
 
     /**
      * @var string
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $copyright;
 
     /**
      * @var string
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $license;
 
     /**
      * @var string
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $line2 = array('en' => '');
 

--- a/src/Pumukit/SchemaBundle/Document/SeriesStyle.php
+++ b/src/Pumukit/SchemaBundle/Document/SeriesStyle.php
@@ -21,14 +21,14 @@ class SeriesStyle
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $name;
 
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $text;
 

--- a/src/Pumukit/SchemaBundle/Document/SeriesType.php
+++ b/src/Pumukit/SchemaBundle/Document/SeriesType.php
@@ -24,21 +24,21 @@ class SeriesType
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $name = array('en' => '');
 
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $description = array('en' => '');
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $cod = 0;
 

--- a/src/Pumukit/SchemaBundle/Document/Tag.php
+++ b/src/Pumukit/SchemaBundle/Document/Tag.php
@@ -28,7 +28,7 @@ class Tag
      *
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      * @MongoDB\Increment
      */
     private $number_multimedia_objects = 0;
@@ -36,28 +36,28 @@ class Tag
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $title = array('en' => '');
 
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $description = array('en' => '');
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $slug;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      * @MongoDB\UniqueIndex(order="asc")
      * @Assert\Regex("/^\w*$/")
      * @Gedmo\TreePathSource
@@ -69,14 +69,14 @@ class Tag
     /**
      * @var bool
      *
-     * @MongoDB\Boolean
+     * @MongoDB\Field(type="boolean")
      */
     private $metatag = false;
 
     /**
      * @var bool
      *
-     * @MongoDB\Boolean
+     * @MongoDB\Field(type="boolean")
      */
     private $display = false;
 
@@ -91,14 +91,14 @@ class Tag
     /**
      * @var date
      *
-     * @MongoDB\Date
+     * @MongoDB\Field(type="date")
      */
     private $created;
 
     /**
      * @var date
      *
-     * @MongoDB\Date
+     * @MongoDB\Field(type="date")
      */
     private $updated;
 
@@ -119,7 +119,7 @@ class Tag
      *
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      * @MongoDB\Increment
      */
     private $number_children = 0;

--- a/src/Pumukit/SchemaBundle/Document/Track.php
+++ b/src/Pumukit/SchemaBundle/Document/Track.php
@@ -14,84 +14,84 @@ class Track extends Element
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $language;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $acodec;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $vcodec;
 
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      */
     private $bitrate;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $framerate;
 
     /**
      * @var bool
      *
-     * @MongoDB\Boolean
+     * @MongoDB\Field(type="boolean")
      */
     private $only_audio;
 
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      */
     private $channels;
 
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      */
     private $duration = 0;
 
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      */
     private $width;
 
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      */
     private $height;
 
     /**
      * @var bool
      *
-     * @MongoDB\Boolean
+     * @MongoDB\Field(type="boolean")
      */
     private $allowDownload = false;
 
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      * @MongoDB\Increment
      */
     private $numview;

--- a/src/Pumukit/SchemaBundle/Document/Traits/Keywords.php
+++ b/src/Pumukit/SchemaBundle/Document/Traits/Keywords.php
@@ -12,14 +12,14 @@ trait Keywords
      * @deprecated in version 2.3
      * use keywords instead
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $keyword = array('en' => '');
 
     /**
      * @var array
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $keywords = array('en' => array());
 

--- a/src/Pumukit/SchemaBundle/Document/Traits/Properties.php
+++ b/src/Pumukit/SchemaBundle/Document/Traits/Properties.php
@@ -9,7 +9,7 @@ trait Properties
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $properties = array();
 

--- a/src/Pumukit/SchemaBundle/Document/User.php
+++ b/src/Pumukit/SchemaBundle/Document/User.php
@@ -38,14 +38,14 @@ class User extends BaseUser
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     protected $fullname;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     protected $origin = self::ORIGIN_LOCAL;
 

--- a/src/Pumukit/StatsBundle/Document/Traits/Properties.php
+++ b/src/Pumukit/StatsBundle/Document/Traits/Properties.php
@@ -9,7 +9,7 @@ trait Properties
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $properties = array();
 

--- a/src/Pumukit/StatsBundle/Document/ViewsAggregation.php
+++ b/src/Pumukit/StatsBundle/Document/ViewsAggregation.php
@@ -23,7 +23,7 @@ class ViewsAggregation
     /**
      * @var \Date
      *
-     * @MongoDB\Date
+     * @MongoDB\Field(type="date")
      * @MongoDB\Index
      */
     private $date;
@@ -31,7 +31,7 @@ class ViewsAggregation
     /**
      * @var string
      *
-     * @MongoDB\ObjectId
+     * @MongoDB\Field(type="object_id")
      * @MongoDB\Index
      */
     private $multimediaObject;
@@ -39,7 +39,7 @@ class ViewsAggregation
     /**
      * @var string
      *
-     * @MongoDB\ObjectId
+     * @MongoDB\Field(type="object_id")
      * @MongoDB\Index
      */
     private $series;
@@ -47,7 +47,7 @@ class ViewsAggregation
     /**
      * @var int
      *
-     * @MongoDB\Int
+     * @MongoDB\Field(type="int")
      * @MongoDB\Increment
      */
     private $numView;

--- a/src/Pumukit/StatsBundle/Document/ViewsLog.php
+++ b/src/Pumukit/StatsBundle/Document/ViewsLog.php
@@ -23,7 +23,7 @@ class ViewsLog
     /**
      * @var \Date
      *
-     * @MongoDB\Date
+     * @MongoDB\Field(type="date")
      * @MongoDB\Index
      */
     private $date;
@@ -31,35 +31,35 @@ class ViewsLog
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $url;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $ip;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $userAgent;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $referer;
 
     /**
      * @var string
      *
-     * @MongoDB\ObjectId
+     * @MongoDB\Field(type="object_id")
      * @MongoDB\Index
      */
     private $multimediaObject;
@@ -67,7 +67,7 @@ class ViewsLog
     /**
      * @var string
      *
-     * @MongoDB\ObjectId
+     * @MongoDB\Field(type="object_id")
      * @MongoDB\Index
      */
     private $series;
@@ -75,14 +75,14 @@ class ViewsLog
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $track;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      */
     private $user;
 

--- a/src/Pumukit/TemplateBundle/Document/Template.php
+++ b/src/Pumukit/TemplateBundle/Document/Template.php
@@ -21,28 +21,28 @@ class Template
     /**
      * @var bool
      *
-     * @MongoDB\Boolean
+     * @MongoDB\Field(type="boolean")
      */
     private $hide = false;
 
     /**
      * @var date
      *
-     * @MongoDB\Date
+     * @MongoDB\Field(type="date")
      */
     private $createdAt;
 
     /**
      * @var date
      *
-     * @MongoDB\Date
+     * @MongoDB\Field(type="date")
      */
     private $updatedAt;
 
     /**
      * @var string
      *
-     * @MongoDB\String
+     * @MongoDB\Field(type="string")
      * @MongoDB\UniqueIndex(order="asc")
      */
     private $name = '';
@@ -50,7 +50,7 @@ class Template
     /**
      * @var string
      *
-     * @MongoDB\Raw
+     * @MongoDB\Field(type="raw")
      */
     private $text = array('en' => '');
 


### PR DESCRIPTION
```
  [Symfony\Component\Debug\Exception\FatalErrorException]
  Compile Error: Cannot use 'String' as class name as it is reserved
  Compile Error: Cannot use 'Int' as class name as it is reserved
  Compile Error: Cannot use 'Bool' as class name as it is reserved
  ...
```

See: https://github.com/doctrine/DoctrineMongoDBBundle/issues/351

Solution:
```
find src -name \*php -exec sed -i "s/MongoDB\\\String/MongoDB\\\Field(type=\"string\")/g" {} \;
find src -name \*php -exec sed -i "s/MongoDB\\\Int/MongoDB\\\Field(type=\"int\")/g" {} \;
find src -name \*php -exec sed -i "s/MongoDB\\\Boolean/MongoDB\\\Field(type=\"boolean\")/g" {} \;
find src -name \*php -exec sed -i "s/MongoDB\\\ObjectId/MongoDB\\\Field(type=\"object_id\")/g" {} \;
find src -name \*php -exec sed -i "s/MongoDB\\\Raw/MongoDB\\\Field(type=\"raw\")/g" {} \;
find src -name \*php -exec sed -i "s/MongoDB\\\Date/MongoDB\\\Field(type=\"date\")/g" {} \;
find src -name \*php -exec sed -i "s/MongoDB\\\Collection/MongoDB\\\Field(type=\"collection\")/g" {} \;
```