### PR TITLE
PHP7 Cannot use ODM annotations as class name as it is reserved (II)

### DIFF
--- a/src/Pumukit/SchemaBundle/Document/MultimediaObject.php
+++ b/src/Pumukit/SchemaBundle/Document/MultimediaObject.php
@@ -49,7 +49,7 @@ class MultimediaObject
 
     /**
      * @var bool
-     * @MongoDB\Bool
+     * @MongoDB\Field(type="boolean")
      * @MongoDB\Index
      */
     private $islive = false;


### PR DESCRIPTION
```
  [Symfony\Component\Debug\Exception\FatalErrorException]
  Compile Error: Cannot use 'String' as class name as it is reserved
  Compile Error: Cannot use 'Int' as class name as it is reserved
  Compile Error: Cannot use 'Bool' as class name as it is reserved
  ...
```

See: https://github.com/doctrine/DoctrineMongoDBBundle/issues/351

Solution:

```
find src -name \*php -exec sed -i "s/MongoDB\\\String/MongoDB\\\Field(type=\"string\")/g" {} \;
find src -name \*php -exec sed -i "s/MongoDB\\\Int/MongoDB\\\Field(type=\"int\")/g" {} \;
find src -name \*php -exec sed -i "s/MongoDB\\\Boolean/MongoDB\\\Field(type=\"boolean\")/g" {} \;
find src -name \*php -exec sed -i "s/MongoDB\\\Bool/MongoDB\\\Field(type=\"boolean\")/g" {} \;
find src -name \*php -exec sed -i "s/MongoDB\\\ObjectId/MongoDB\\\Field(type=\"object_id\")/g" {} \;
find src -name \*php -exec sed -i "s/MongoDB\\\Raw/MongoDB\\\Field(type=\"raw\")/g" {} \;
find src -name \*php -exec sed -i "s/MongoDB\\\Date/MongoDB\\\Field(type=\"date\")/g" {} \;
find src -name \*php -exec sed -i "s/MongoDB\\\Collection/MongoDB\\\Field(type=\"collection\")/g" {} \;
```