### PR TITLE
TTK-18654: Fix info about series when rendering from video magic url

### DIFF
--- a/src/Pumukit/WebTVBundle/Controller/MultimediaObjectController.php
+++ b/src/Pumukit/WebTVBundle/Controller/MultimediaObjectController.php
@@ -141,8 +141,10 @@ class MultimediaObjectController extends PlayerController implements WebTVContro
         $secretSeriesUrl = $this->generateUrl('pumukit_webtv_series_magicindex', array('secret' => $series->getSecret()), true);
         $fromSecret = 0 === strpos($referer, $secretSeriesUrl);
         $relatedLink = strpos($referer, 'magic');
+        $multimediaObjectMagicUrl = $request->get('magicUrl', false);
 
-        $status = ($fromSecret || $relatedLink) ?
+        $showMagicUrl = ($fromSecret || $relatedLink || $multimediaObjectMagicUrl);
+        $status = ($showMagicUrl) ?
                 array(MultimediaObject::STATUS_PUBLISHED, MultimediaObject::STATUS_HIDDEN) :
                 array(MultimediaObject::STATUS_PUBLISHED);
 
@@ -151,7 +153,7 @@ class MultimediaObjectController extends PlayerController implements WebTVContro
         return array(
             'series' => $series,
             'multimediaObjects' => $multimediaObjects,
-            'showMagicUrl' => ($fromSecret || $relatedLink),
+            'showMagicUrl' => $showMagicUrl,
         );
     }
 

--- a/src/Pumukit/WebTVBundle/Resources/views/MultimediaObject/index.html.twig
+++ b/src/Pumukit/WebTVBundle/Resources/views/MultimediaObject/index.html.twig
@@ -37,7 +37,7 @@
     <div class="col-lg-4 col-md-5">
         <span class="hidden-sm hidden-xs"><br/></span>
         {% if not multimediaObject.getSeries().isHide() %}
-            {% render(controller('PumukitWebTVBundle:MultimediaObject:series', {'multimediaObject': multimediaObject, 'magicUrl': magic_url is defined})) %}
+            {% render(controller('PumukitWebTVBundle:MultimediaObject:series', {'multimediaObject': multimediaObject, 'magicUrl': magic_url is defined ? magic_url : false})) %}
         {% endif %}
         {% render(controller('PumukitWebTVBundle:MultimediaObject:related', {'multimediaObject': multimediaObject})) %}
     </div>

--- a/src/Pumukit/WebTVBundle/Resources/views/MultimediaObject/index.html.twig
+++ b/src/Pumukit/WebTVBundle/Resources/views/MultimediaObject/index.html.twig
@@ -37,7 +37,7 @@
     <div class="col-lg-4 col-md-5">
         <span class="hidden-sm hidden-xs"><br/></span>
         {% if not multimediaObject.getSeries().isHide() %}
-            {% render(controller('PumukitWebTVBundle:MultimediaObject:series', {'multimediaObject': multimediaObject})) %}
+            {% render(controller('PumukitWebTVBundle:MultimediaObject:series', {'multimediaObject': multimediaObject, 'magicUrl': magic_url is defined})) %}
         {% endif %}
         {% render(controller('PumukitWebTVBundle:MultimediaObject:related', {'multimediaObject': multimediaObject})) %}
     </div>


### PR DESCRIPTION
This PR adds info in WebTVBundle:MultimediaObject:seriesAction about the request coming from WebTVBundle:MultimediaObject:index.html.twig to discern about magic url.