### PR TITLE
WebTVBundle: Edit button. Changed mmobj filter to AdminController

### DIFF
--- a/src/Pumukit/WebTVBundle/Controller/SecurityController.php
+++ b/src/Pumukit/WebTVBundle/Controller/SecurityController.php
@@ -7,9 +7,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Pumukit\SchemaBundle\Document\MultimediaObject;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
-use Pumukit\CoreBundle\Controller\AdminController;
 
-class SecurityController extends Controller implements AdminController
+class SecurityController extends Controller
 {
     /**
      * @param Request          $request

--- a/src/Pumukit/WebTVBundle/Controller/SecurityController.php
+++ b/src/Pumukit/WebTVBundle/Controller/SecurityController.php
@@ -7,8 +7,9 @@ use Symfony\Component\HttpFoundation\Request;
 use Pumukit\SchemaBundle\Document\MultimediaObject;
 use Symfony\Component\Routing\Annotation\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Pumukit\CoreBundle\Controller\AdminController;
 
-class SecurityController extends Controller implements WebTVController
+class SecurityController extends Controller implements AdminController
 {
     /**
      * @param Request          $request


### PR DESCRIPTION
If the multimedia object is not published, this route always returns a 404.

This route should be consistent with the back-office, so I changed the filter from the WebTVController to the AdminController.