### PR TITLE
Hotfix phpstan

### DIFF
--- a/src/Pumukit/SchemaBundle/Command/NumericalIDCommand.php
+++ b/src/Pumukit/SchemaBundle/Command/NumericalIDCommand.php
@@ -15,7 +15,6 @@ class NumericalIDCommand extends ContainerAwareCommand
     private $step;
     private $force;
     private $output;
-    private $limit;
 
     protected function configure()
     {
@@ -38,7 +37,6 @@ EOT
         $this->dm = $this->getContainer()->get('doctrine_mongodb')->getManager();
         $this->step = $input->getOption('step');
         $this->force = (true === $input->getOption('force'));
-        $this->limit = 100;
 
         $this->output = $output;
     }
@@ -106,7 +104,7 @@ EOT
             'numerical_id' => array('$exists' => false),
         );
 
-        $multimediaObjects = $this->getMultimediaObjects($criteria, true, $this->limit);
+        $multimediaObjects = $this->getMultimediaObjects($criteria, true);
         $series = $this->getSeries($criteria, true);
 
         if ($multimediaObjects || $series) {


### PR DESCRIPTION
Line   Pumukit/SchemaBundle/Command/NumericalIDCommand.php                      
 ------ ------------------------------------------------------------------------- 
  109    Method                                                                   
         Pumukit\SchemaBundle\Command\NumericalIDCommand::getMultimediaObjects()  
         invoked with 3 parameters, 1-2 required.                