### PR TITLE
TTK-20182 WebTVBundle: Added analytics template to base 

### DIFF
--- a/src/Pumukit/WebTVBundle/Resources/views/Layout/base.html.twig
+++ b/src/Pumukit/WebTVBundle/Resources/views/Layout/base.html.twig
@@ -84,5 +84,6 @@
         {% endblock %}
     </div>
 {% endblock %}
+{% include 'PumukitWebTVBundle:Layout:analytics.html.twig' %}
 </body>
 </html>

--- a/src/Pumukit/WebTVBundle/Resources/views/Layout/base.html.twig
+++ b/src/Pumukit/WebTVBundle/Resources/views/Layout/base.html.twig
@@ -84,6 +84,8 @@
         {% endblock %}
     </div>
 {% endblock %}
-{% include 'PumukitWebTVBundle:Layout:analytics.html.twig' %}
+{% if not app.request.xmlHttpRequest %}
+    {% include 'PumukitWebTVBundle:Layout:analytics.html.twig' %}
+{% endif %}
 </body>
 </html>


### PR DESCRIPTION
This solves two issues:
* We avoid having having to use the footer to add analytics
* Analytics appear on the back-office as well