### PR TITLE
PersonService: Adds an optional 'dispatch' flag

### DIFF
--- a/src/Pumukit/SchemaBundle/Services/PersonService.php
+++ b/src/Pumukit/SchemaBundle/Services/PersonService.php
@@ -205,7 +205,7 @@ class PersonService
      *
      * @return MultimediaObject
      */
-    public function createRelationPerson(Person $person, Role $role, MultimediaObject $multimediaObject, $flush = true)
+    public function createRelationPerson(Person $person, Role $role, MultimediaObject $multimediaObject, $flush = true, $dispatch = true)
     {
         $this->dm->persist($person);
         $multimediaObject->addPersonWithRole($person, $role);
@@ -220,7 +220,9 @@ class PersonService
             $this->dm->flush();
         }
 
-        $this->dispatcher->dispatchCreate($multimediaObject, $person, $role);
+        if($dispatch) {
+            $this->dispatcher->dispatchCreate($multimediaObject, $person, $role);
+        }
 
         return $multimediaObject;
     }


### PR DESCRIPTION
If false, the function won't dispatch the mmobj_update event
This helps optimize the code when having to call this function several times in a row,
as it stands now, each mmobj_update makes a mongo query to update the text index.