### PR TITLE
Workaround to fix travis with FutureWebTVBundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,9 @@ script:
     - find src -type f -name "*.php" -print0 | xargs -0 -n1 -P8 php -l
     - php app/console lint:yaml src
     - php app/console lint:yaml app
+    - mv src/Pumukit/FutureWebTVBundle /tmp # workaround
     - php app/console lint:twig src
+    - mv /tmp/FutureWebTVBundle src/Pumukit # workaround
     - php app/console lint:twig app
     - ./bin/travis_checks/check_var_dumps
     - php bin/php-cs-fixer fix src --rules=@Symfony --dry-run -v


### PR DESCRIPTION
The command "php app/console lint:twig src" exited with 1.

  >> Unknown "col_calculator" function.
  >> Unknown "add_clear_fix_md" function.
...