### PR TITLE
TTK-21375 Workflow: not generate new job for published video

### DIFF
--- a/src/Pumukit/WorkflowBundle/EventListener/JobGeneratorListener.php
+++ b/src/Pumukit/WorkflowBundle/EventListener/JobGeneratorListener.php
@@ -80,6 +80,14 @@ class JobGeneratorListener
         $jobs = array();
         $default_profiles = $this->profileService->getDefaultProfiles();
 
+        if ($this->containsTrackWithProfileWithTargetTag($multimediaObject, $pubChannelCod)) {
+            $this->logger->info(sprintf("JobGeneratorListener can't create a new job for multimedia object %s,".
+                                        'because it already contains a track with a profile with this target (%s)',
+                                        $multimediaObject->getId(), $pubChannelCod));
+
+            return $jobs;
+        }
+
         foreach ($this->profiles as $targetProfile => $profile) {
             $targets = $this->getTargets($profile['target']);
 
@@ -157,5 +165,20 @@ class JobGeneratorListener
         }
 
         return $return;
+    }
+
+    private function containsTrackWithProfileWithTargetTag(MultimediaObject $multimediaObject, $pubChannelCod)
+    {
+        foreach ($multimediaObject->getTracks() as $track) {
+            $profileName = $track->getProfileName();
+            if ($profileName && isset($this->profiles[$profileName])) {
+                $targets = $this->getTargets($this->profiles[$profileName]['target']);
+                if (in_array($pubChannelCod, $targets['standard'])) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Pumukit/WorkflowBundle/Tests/EventListener/JobGeneratorListenerTest.php
+++ b/src/Pumukit/WorkflowBundle/Tests/EventListener/JobGeneratorListenerTest.php
@@ -174,6 +174,23 @@ class JobGeneratorListenerTest extends WebTestCase
         /* $this->assertEquals(array(), $jobs);  //generate a video from an audio has no sense. */
     }
 
+    public function testNotGenerateJobsForPublishedVideo()
+    {
+        $track = new Track();
+        $track->setTags(array('master', 'profile:video'));
+        $track->setPath('path');
+        $track->setOnlyAudio(false);
+        $track->setWidth(640);
+        $track->setHeight(480);
+        $mmobj = new MultimediaObject();
+        $mmobj->addTrack($track);
+
+        $jobs = $this->invokeMethod($this->jobGeneratorListener, 'generateJobs', array($mmobj, 'TAGC'));
+        $this->assertEquals(array(), $jobs);
+
+        //$this->assertEquals(1, 2);
+    }
+
     private function invokeMethod(&$object, $methodName, array $parameters = array())
     {
         $reflection = new \ReflectionClass(get_class($object));


### PR DESCRIPTION
Not generate a new job with video_h264 profile if the multimedia object already contains other with PUCHWEBTV