### PR TITLE
TTK-21710 NewAdminBundle: Added 'trans' to button hover title

### DIFF
--- a/src/Pumukit/NewAdminBundle/Resources/views/MultimediaObject/index.html.twig
+++ b/src/Pumukit/NewAdminBundle/Resources/views/MultimediaObject/index.html.twig
@@ -75,7 +75,7 @@
                             {# RENDERS ANY BUTTONS DEFINED IN AN EXTRA PLUGIN #}
                             {% for item in get_extra_buttons() %}
                                 {% if app.user and is_granted(item.accessRole) %}
-                                    <a title="{{ item.name }}" class="btn btn-pumukit btn-raised" href="{{ path(item.uri, {'series': series.id }) }}">
+                                    <a title="{{ item.name | trans }}" class="btn btn-pumukit btn-raised" href="{{ path(item.uri, {'series': series.id }) }}">
                                         <i class="mdi-content-add"></i>
                                         {{ item.name | trans }}
                                     </a>


### PR DESCRIPTION
I noticed that this title is not translated. It should be, it probably was an oversight.